### PR TITLE
밸런스게임 생성(or 수정 or 임시 저장) API 요청 시 GAME_OPTION 테이블의 GAME_ID가 null로 저장되는 이슈 해결

### DIFF
--- a/src/main/java/balancetalk/game/dto/TempGameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameSetDto.java
@@ -27,6 +27,7 @@ public class TempGameSetDto {
             return TempGameSet.builder()
                     .mainTag(mainTag)
                     .subTag(subTag)
+                    .tempGames(tempGames.stream().map(CreateTempGameRequest::toEntity).toList())
                     .member(member)
                     .build();
         }
@@ -42,7 +43,7 @@ public class TempGameSetDto {
         public static TempGameSetResponse fromEntity(TempGameSet tempGameSet) {
             return TempGameSetResponse.builder()
                     .tempGameDetailResponses(tempGameSet.getTempGames().stream()
-                            .map(tempGame -> TempGameDetailResponse.fromEntity(tempGame)).toList()
+                            .map(TempGameDetailResponse::fromEntity).toList()
                     ).build();
         }
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] game_option의 game_id에 null이 들어가지 않도록 수정
- [x] temp_game_option의 temp_game_id에 null이 들어가지 않도록 수정

## 💡 자세한 설명
각 game을 List에 저장하도록 반복하고, 해당 List를 gameSet에 추가하는 방식으로 오류를 해결했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #684 
