### PR TITLE
톡픽 임시 저장 시 모든 필드에 대한 공백 허용

### DIFF
--- a/src/main/java/balancetalk/talkpick/domain/TempTalkPick.java
+++ b/src/main/java/balancetalk/talkpick/domain/TempTalkPick.java
@@ -21,20 +21,16 @@ public class TempTalkPick {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @NotBlank
     @Size(max = 50)
     private String title;
 
-    @NotBlank
     @Column(columnDefinition = "LONGTEXT")
     private String content;
 
-    @NotBlank
     @Size(max = 10)
     @Column(name = "option_a")
     private String optionA;
 
-    @NotBlank
     @Size(max = 10)
     @Column(name = "option_b")
     private String optionB;

--- a/src/main/java/balancetalk/talkpick/dto/BaseTalkPickFields.java
+++ b/src/main/java/balancetalk/talkpick/dto/BaseTalkPickFields.java
@@ -1,7 +1,6 @@
 package balancetalk.talkpick.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,21 +12,17 @@ import lombok.Getter;
 public class BaseTalkPickFields {
 
     @Schema(description = "제목", example = "제목")
-    @NotBlank(message = "제목은 공백을 허용하지 않습니다.")
     @Size(max = 50, message = "제목은 50자 이하여야 합니다.")
     private String title;
 
     @Schema(description = "본문 내용", example = "본문 내용")
-    @NotBlank(message = "본문 내용은 공백을 허용하지 않습니다.")
     private String content;
 
     @Schema(description = "선택지 A 이름", example = "선택지 A 이름")
-    @NotBlank(message = "선택지 이름은 공백을 허용하지 않습니다.")
     @Size(max = 10, message = "선택지 이름은 10자 이하여야 합니다.")
     private String optionA;
 
     @Schema(description = "선택지 B 이름", example = "선택지 B 이름")
-    @NotBlank(message = "선택지 이름은 공백을 허용하지 않습니다.")
     @Size(max = 10, message = "선택지 이름은 10자 이하여야 합니다.")
     private String optionB;
 

--- a/src/main/java/balancetalk/talkpick/dto/BaseTempTalkPickFields.java
+++ b/src/main/java/balancetalk/talkpick/dto/BaseTempTalkPickFields.java
@@ -9,21 +9,25 @@ public class BaseTempTalkPickFields extends BaseTalkPickFields {
     }
 
     @NotBlank(message = "제목은 공백을 허용하지 않습니다.")
+    @Override
     public String getTitle() {
         return super.getTitle();
     }
 
     @NotBlank(message = "본문 내용은 공백을 허용하지 않습니다.")
+    @Override
     public String getContent() {
         return super.getContent();
     }
 
     @NotBlank(message = "선택지 이름은 공백을 허용하지 않습니다.")
+    @Override
     public String getOptionA() {
         return super.getOptionA();
     }
 
     @NotBlank(message = "선택지 이름은 공백을 허용하지 않습니다.")
+    @Override
     public String getOptionB() {
         return super.getOptionA();
     }

--- a/src/main/java/balancetalk/talkpick/dto/BaseTempTalkPickFields.java
+++ b/src/main/java/balancetalk/talkpick/dto/BaseTempTalkPickFields.java
@@ -1,0 +1,30 @@
+package balancetalk.talkpick.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class BaseTempTalkPickFields extends BaseTalkPickFields {
+
+    public BaseTempTalkPickFields(String title, String content, String optionA, String optionB, String sourceUrl) {
+        super(title, content, optionA, optionB, sourceUrl);
+    }
+
+    @NotBlank(message = "제목은 공백을 허용하지 않습니다.")
+    public String getTitle() {
+        return super.getTitle();
+    }
+
+    @NotBlank(message = "본문 내용은 공백을 허용하지 않습니다.")
+    public String getContent() {
+        return super.getContent();
+    }
+
+    @NotBlank(message = "선택지 이름은 공백을 허용하지 않습니다.")
+    public String getOptionA() {
+        return super.getOptionA();
+    }
+
+    @NotBlank(message = "선택지 이름은 공백을 허용하지 않습니다.")
+    public String getOptionB() {
+        return super.getOptionA();
+    }
+}

--- a/src/main/java/balancetalk/talkpick/dto/TempTalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TempTalkPickDto.java
@@ -15,7 +15,7 @@ public class TempTalkPickDto {
     @AllArgsConstructor
     public static class SaveTempTalkPickRequest {
 
-        private BaseTalkPickFields baseFields;
+        private BaseTempTalkPickFields baseFields;
 
         @Schema(description = "첨부한 이미지 ID 목록", example = "[214, 24]")
         private List<Long> fileIds;


### PR DESCRIPTION
## 💡 작업 내용
- [x] TempTalkPick 엔티티 클래스의 모든 필드에서 공백 검증 어노테이션 제거
- [x] DTO 검증 로직 분리

## 💡 자세한 설명
원래 `BaseTalkPickFields`에는 모든 필드에 `@NotBlank` 어노테이션이 적용되어 있었습니다. 하지만 `TempTalkPickDto`의 경우 모든 필드에 대해 이러한 검증이 필요하지 않았습니다.

이에 따라 `BaseTempTalkPickFields`를 새로 만들어 상속 구조를 도입했습니다. 이를 통해 `TempTalkPickDto`에서는 필요한 검증만 적용할 수 있게 되었고, 기존 `BaseTalkPickFields`도 유지할 수 있게 되었습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #694 
