### PR TITLE
톡픽 엔티티에 수정 여부 필드 추가

### DIFF
--- a/src/main/java/balancetalk/talkpick/domain/TalkPick.java
+++ b/src/main/java/balancetalk/talkpick/domain/TalkPick.java
@@ -65,6 +65,8 @@ public class TalkPick extends BaseTimeEntity {
 
     private LocalDateTime editedAt;
 
+    private boolean isEdited;
+
     @Enumerated(value = EnumType.STRING)
     private ViewStatus viewStatus = ViewStatus.NORMAL;
 
@@ -106,6 +108,7 @@ public class TalkPick extends BaseTimeEntity {
         this.optionB = newTalkPick.getOptionB();
         this.sourceUrl = newTalkPick.getSourceUrl();
         this.editedAt = LocalDateTime.now();
+        this.isEdited = true;
     }
 
     public boolean matchesId(long id) {
@@ -113,7 +116,7 @@ public class TalkPick extends BaseTimeEntity {
     }
 
     public boolean isEdited() {
-        return editedAt != null;
+        return isEdited;
     }
 
     public void updateSummary(Summary newSummary) {

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -101,7 +101,7 @@ public class TalkPickDto {
         private LocalDate createdAt;
 
         @Schema(description = "수정 여부", example = "true")
-        private Boolean isUpdated;
+        private Boolean isEdited;
 
         public static TalkPickDetailResponse from(TalkPick entity,
                                                   List<String> imgUrls,
@@ -128,7 +128,7 @@ public class TalkPickDto {
                     .votedOption(votedOption)
                     .writer(entity.getWriterNickname())
                     .createdAt(entity.getCreatedAt().toLocalDate())
-                    .isUpdated(entity.isEdited())
+                    .isEdited(entity.isEdited())
                     .build();
         }
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 엔티티에 isEdited 필드 추가
- [x] ERD 업데이트

## 💡 자세한 설명
톡픽 상세 조회 시, 기존에는 editedAt이 null인지에 따라 해당 톡픽 수정 여부를 결정했습니다.
하지만 마이페이지에서 '내가 작성한 톡픽 조회' 기능에서 editedAt을 이용한 정렬이 필요하기 때문에, 톡픽의 editedAt을 null로 설정할 수 없습니다.
따라서 톡픽 수정 여부를 나타내는 isEdited 필드를 추가합니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #698 
