### PR TITLE
프론트 도메인 CORS 허용 완료

### DIFF
--- a/src/main/java/balancetalk/global/config/SecurityConfig.java
+++ b/src/main/java/balancetalk/global/config/SecurityConfig.java
@@ -81,6 +81,7 @@ public class SecurityConfig {
         configuration.addAllowedHeader("Accept");
         configuration.addAllowedHeader("Authorization");
         configuration.addAllowedHeader("refreshToken");
+        configuration.addAllowedHeader("accessToken");
         configuration.addAllowedHeader("Content-Type");
         configuration.addAllowedHeader("Origin");
         configuration.addAllowedHeader("Cookie");
@@ -97,8 +98,6 @@ public class SecurityConfig {
         configuration.addAllowedHeader("User-Agent");
         configuration.addAllowedHeader("Sec-Fetch-Mode");
         configuration.addAllowedHeader("Sec-Fetch-Site");;
-        configuration.addExposedHeader("Authorization");
-        configuration.addExposedHeader("refreshToken");
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(MAX_AGE_SEC);

--- a/src/main/java/balancetalk/global/config/SecurityConfig.java
+++ b/src/main/java/balancetalk/global/config/SecurityConfig.java
@@ -76,7 +76,27 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedOriginPattern("http://localhost:8080");
         configuration.addAllowedOriginPattern("http://localhost:3000"); // 프론트 쪽에서 허용
-        configuration.addAllowedOriginPattern("https://balancetalk.kro.kr"); // 도메인 주소
+        configuration.addAllowedOriginPattern("https://pick0.com"); // 도메인 주소
+        configuration.addAllowedOriginPattern("https://api.pick0.com"); // 도메인 주소
+        configuration.addAllowedHeader("Accept");
+        configuration.addAllowedHeader("Authorization");
+        configuration.addAllowedHeader("refreshToken");
+        configuration.addAllowedHeader("Content-Type");
+        configuration.addAllowedHeader("Origin");
+        configuration.addAllowedHeader("Cookie");
+        configuration.addAllowedHeader("X-Requested-With");
+        configuration.addAllowedHeader("Access-Control-Allow-Origin");
+        configuration.addAllowedHeader("Access-Control-Allow-Credentials");
+        configuration.addAllowedHeader("Access-Control-Allow-Methods");
+        configuration.addAllowedHeader("Access-Control-Allow-Headers");
+        configuration.addAllowedHeader("Host");
+        configuration.addAllowedHeader("Connection");
+        configuration.addAllowedHeader("Accept-Encoding");
+        configuration.addAllowedHeader("Accept-Language");
+        configuration.addAllowedHeader("Referer");
+        configuration.addAllowedHeader("User-Agent");
+        configuration.addAllowedHeader("Sec-Fetch-Mode");
+        configuration.addAllowedHeader("Sec-Fetch-Site");;
         configuration.addExposedHeader("Authorization");
         configuration.addExposedHeader("refreshToken");
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE"));


### PR DESCRIPTION
## 💡 작업 내용
- [x] SecurityConfig 수정

## 💡 자세한 설명
변경된 프론트 도메인을 허용하고, 쿠키 발급 시 CORS를 방지하기 위해 허용 가능한 헤더를 명시했습니다. (와일드카드는 보안 정책 때문에 사용 불가)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #706


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- CORS 구성 변경으로 허용된 출처 패턴이 업데이트되었습니다.
	- 새로운 허용된 출처로 "https://pick0.com" 및 "https://api.pick0.com" 추가.
	- 다양한 허용된 헤더가 추가되어 보안 정책이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->