### PR TITLE
톡픽 투표 비회원 접근 제한

### DIFF
--- a/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
+++ b/src/main/java/balancetalk/vote/application/VoteTalkPickService.java
@@ -37,7 +37,6 @@ import balancetalk.vote.domain.VoteOption;
 import balancetalk.vote.dto.VoteTalkPickDto.VoteRequest;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -208,7 +207,7 @@ public class VoteTalkPickService {
         return talkPick.getVotes().stream()
                 .filter(vote -> vote.getVoteOption().equals(option))
                 .map(TalkPickVote::getMember)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private void sendNotificationToMembers(Member member, TalkPick talkPick, String category, String message) {

--- a/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
+++ b/src/main/java/balancetalk/vote/presentation/VoteTalkPickController.java
@@ -1,8 +1,9 @@
 package balancetalk.vote.presentation;
 
+import static balancetalk.vote.dto.VoteTalkPickDto.VoteRequest;
+
 import balancetalk.global.utils.AuthPrincipal;
 import balancetalk.member.dto.ApiMember;
-import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.vote.application.VoteTalkPickService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,8 +18,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static balancetalk.vote.dto.VoteTalkPickDto.VoteRequest;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/votes/talks/{talkPickId}")
@@ -31,8 +30,8 @@ public class VoteTalkPickController {
     @PostMapping
     public void createVoteTalkPick(@PathVariable long talkPickId,
                                    @RequestBody @Valid VoteRequest request,
-                                   @Parameter(hidden = true) @AuthPrincipal GuestOrApiMember guestOrApiMember) {
-        voteTalkPickService.createVote(talkPickId, request, guestOrApiMember);
+                                   @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        voteTalkPickService.createVote(talkPickId, request, apiMember);
     }
 
     @Operation(summary = "톡픽 투표 수정", description = "톡픽 투표를 수정합니다.")

--- a/src/test/java/balancetalk/vote/application/VoteTalkPickServiceTest.java
+++ b/src/test/java/balancetalk/vote/application/VoteTalkPickServiceTest.java
@@ -1,24 +1,22 @@
 package balancetalk.vote.application;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.member.domain.Member;
 import balancetalk.member.dto.ApiMember;
-import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.TalkPickReader;
 import balancetalk.vote.domain.TalkPickVote;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class VoteTalkPickServiceTest {
@@ -28,9 +26,6 @@ class VoteTalkPickServiceTest {
 
     @Mock
     TalkPickReader talkPickReader;
-
-    @Mock
-    GuestOrApiMember guestOrApiMember;
 
     @Mock
     ApiMember apiMember;
@@ -44,11 +39,10 @@ class VoteTalkPickServiceTest {
         Member member = Member.builder().talkPickVotes(List.of(vote)).build();
 
         when(talkPickReader.readById(any())).thenReturn(talkPick);
-        when(guestOrApiMember.isGuest()).thenReturn(false);
-        when(guestOrApiMember.toMember(any())).thenReturn(member);
+        when(apiMember.toMember(any())).thenReturn(member);
 
         // when, then
-        assertThatThrownBy(() -> voteTalkPickService.createVote(1L, any(), guestOrApiMember))
+        assertThatThrownBy(() -> voteTalkPickService.createVote(1L, any(), apiMember))
                 .isInstanceOf(BalanceTalkException.class);
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 투표 생성 API 파라미터 중 GuestOrApiMember를 ApiMember로 변경

## 💡 자세한 설명
비회원 투표 기능은 클라이언트에서 별도 처리하기로 논의되어 API 호출은 인증된 회원만 가능하도록 수정했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #678 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 투표 프로세스가 인증된 API 회원만을 대상으로 간소화되었습니다.
- **버그 수정**
	- 게스트 투표 처리 로직이 제거되어 투표 관련 메서드가 일관되게 작동합니다.
- **테스트**
	- 테스트에서 게스트 회원 모의 객체가 제거되고 API 회원 모의 객체로 대체되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->