### PR TITLE
톡픽 생성과 수정 요청 DTO 분리

### DIFF
--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -23,10 +23,10 @@ import lombok.Data;
 
 public class TalkPickDto {
 
-    @Schema(description = "톡픽 생성/수정 요청")
+    @Schema(description = "톡픽 생성 요청")
     @Data
     @AllArgsConstructor
-    public static class CreateOrUpdateTalkPickRequest {
+    public static class CreateTalkPickRequest {
 
         private BaseTalkPickFields baseFields;
 
@@ -44,6 +44,33 @@ public class TalkPickDto {
                     .views(0L)
                     .bookmarks(0L)
                     .viewStatus(NORMAL)
+                    .editedAt(LocalDateTime.now())
+                    .build();
+        }
+
+        public boolean containsFileIds() {
+            return fileIds != null;
+        }
+    }
+
+    @Schema(description = "톡픽 수정 요청")
+    @Data
+    @AllArgsConstructor
+    public static class UpdateTalkPickRequest {
+
+        private BaseTalkPickFields baseFields;
+
+        @Schema(description = "첨부한 이미지 파일 ID 목록", example = "[12, 41]")
+        private List<Long> fileIds;
+
+        public TalkPick toEntity(Member member) {
+            return TalkPick.builder()
+                    .member(member)
+                    .title(baseFields.getTitle())
+                    .content(baseFields.getContent())
+                    .optionA(baseFields.getOptionA())
+                    .optionB(baseFields.getOptionB())
+                    .sourceUrl(baseFields.getSourceUrl())
                     .editedAt(LocalDateTime.now())
                     .build();
         }

--- a/src/main/java/balancetalk/talkpick/presentation/TalkPickController.java
+++ b/src/main/java/balancetalk/talkpick/presentation/TalkPickController.java
@@ -1,5 +1,11 @@
 package balancetalk.talkpick.presentation;
 
+import static balancetalk.talkpick.dto.TalkPickDto.CreateTalkPickRequest;
+import static balancetalk.talkpick.dto.TalkPickDto.TalkPickDetailResponse;
+import static balancetalk.talkpick.dto.TalkPickDto.TalkPickResponse;
+import static balancetalk.talkpick.dto.TalkPickDto.UpdateTalkPickRequest;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
 import balancetalk.global.utils.AuthPrincipal;
 import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
@@ -8,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,11 +28,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
-import static balancetalk.talkpick.dto.TalkPickDto.*;
-import static org.springframework.data.domain.Sort.Direction.DESC;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/talks")
@@ -36,7 +38,7 @@ public class TalkPickController {
 
     @Operation(summary = "톡픽 생성", description = "톡픽을 생성합니다.")
     @PostMapping
-    public Long createTalkPick(@RequestBody @Valid final CreateOrUpdateTalkPickRequest request,
+    public Long createTalkPick(@RequestBody @Valid final CreateTalkPickRequest request,
                                @Parameter(hidden = true) @AuthPrincipal final ApiMember apiMember) {
         return talkPickService.createTalkPick(request, apiMember);
     }
@@ -59,7 +61,7 @@ public class TalkPickController {
     @Operation(summary = "톡픽 수정", description = "톡픽을 수정합니다.")
     @PutMapping("/{talkPickId}")
     public void updateTalkPick(@PathVariable final Long talkPickId,
-                               @RequestBody @Valid final CreateOrUpdateTalkPickRequest request,
+                               @RequestBody @Valid final UpdateTalkPickRequest request,
                                @Parameter(hidden = true) @AuthPrincipal final ApiMember apiMember) {
         talkPickService.updateTalkPick(talkPickId, request, apiMember);
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] CreateOrUpdateTalkPickRequest를 생성 요청 DTO와 수정 요청 DTO로 분리

## 💡 자세한 설명
아래와 같이 톡픽 생성 요청과 수정 요청 DTO를 하나로 통일하면, 수정 요청할 때도 조회수와 북마크 수가 0으로 초기화되는 문제가 발생합니다. 
```java
public class TalkPickDto {

    ...

    public static class CreateOrUpdateTalkPickRequest {

        private BaseTalkPickFields baseFields;

        @Schema(description = "첨부한 이미지 파일 ID 목록", example = "[12, 41]")
        private List<Long> fileIds;

        public TalkPick toEntity(Member member) {
            return TalkPick.builder()
                    .member(member)
                    .title(baseFields.getTitle())
                    .content(baseFields.getContent())
                    .optionA(baseFields.getOptionA())
                    .optionB(baseFields.getOptionB())
                    .sourceUrl(baseFields.getSourceUrl())
                    .views(0L)
                    .bookmarks(0L)
                    .viewStatus(NORMAL)
                    .editedAt(LocalDateTime.now())
                    .build();
        }
        ...
```

따라서 CreateOrUpdateTalkPickRequest를 생성 요청 DTO와 수정 요청 DTO로 분리하였습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #704


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - Talk Pick 생성 및 업데이트를 위한 요청 처리 방식 개선.
  - 생성 및 업데이트 요청에 대해 각각 별도의 DTO 클래스 도입.

- **버그 수정**
  - 요청 처리 로직을 명확히 하여 파일 ID 확인 및 파일 이동 로직 통합.

- **문서화**
  - DTO 클래스의 목적 및 스키마 설명 업데이트로 명확성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->