### PR TITLE
리소스 삭제 시 관련 이미지 파일도 삭제되도록 구현

### DIFF
--- a/src/main/java/balancetalk/file/domain/FileHandler.java
+++ b/src/main/java/balancetalk/file/domain/FileHandler.java
@@ -1,5 +1,6 @@
 package balancetalk.file.domain;
 
+import balancetalk.file.domain.repository.FileRepository;
 import io.awspring.cloud.s3.S3Operations;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ public class FileHandler {
 
     private final S3Client s3Client;
     private final S3Operations s3Operations;
+    private final FileRepository fileRepository;
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
@@ -56,5 +58,12 @@ public class FileHandler {
         file.updateS3KeyAndUrl(s3Key, s3EndPoint + s3Key);
         file.updateResourceId(resourceId);
         file.updateFileType(fileType);
+    }
+
+    public void deleteFiles(List<File> files) {
+        for (File file : files) {
+            s3Operations.deleteObject(bucket, file.getS3Key());
+        }
+        fileRepository.deleteAll(files);
     }
 }

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
@@ -11,4 +11,6 @@ public interface FileRepositoryCustom {
     List<Long> findIdsByResourceIdAndFileType(Long resourceId, FileType fileType);
 
     List<File> findAllByResourceIdAndFileType(Long resourceId, FileType fileType);
+
+    List<File> findAllByResourceIdsAndFileType(List<Long> resourceIds, FileType fileType);
 }

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
@@ -1,5 +1,6 @@
 package balancetalk.file.domain.repository;
 
+import balancetalk.file.domain.File;
 import balancetalk.file.domain.FileType;
 import java.util.List;
 
@@ -8,4 +9,6 @@ public interface FileRepositoryCustom {
     List<String> findImgUrlsByResourceIdAndFileType(Long resourceId, FileType fileType);
 
     List<Long> findIdsByResourceIdAndFileType(Long resourceId, FileType fileType);
+
+    List<File> findAllByResourceIdAndFileType(Long resourceId, FileType fileType);
 }

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
@@ -31,4 +31,12 @@ public class FileRepositoryImpl implements FileRepositoryCustom {
                 .where(file.fileType.eq(fileType), file.resourceId.eq(resourceId))
                 .fetch();
     }
+
+    @Override
+    public List<File> findAllByResourceIdAndFileType(Long resourceId, FileType fileType) {
+        return queryFactory.select(file)
+                .from(file)
+                .where(file.fileType.eq(fileType), file.resourceId.eq(resourceId))
+                .fetch();
+    }
 }

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
@@ -39,4 +39,12 @@ public class FileRepositoryImpl implements FileRepositoryCustom {
                 .where(file.fileType.eq(fileType), file.resourceId.eq(resourceId))
                 .fetch();
     }
+
+    @Override
+    public List<File> findAllByResourceIdsAndFileType(List<Long> resourceIds, FileType fileType) {
+        return queryFactory.select(file)
+                .from(file)
+                .where(file.fileType.eq(fileType), file.resourceId.in(resourceIds))
+                .fetch();
+    }
 }

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -131,8 +131,19 @@ public class GameService {
     }
 
     public void deleteBalanceGameSet(final Long gameSetId, final ApiMember apiMember) {
-        apiMember.toMember(memberRepository);
-        gameSetRepository.deleteById(gameSetId);
+        Member member = apiMember.toMember(memberRepository);
+        GameSet gameSet = member.getGameSetById(gameSetId);
+        gameSetRepository.delete(gameSet);
+        List<Long> gameOptionIds = gameSet.getGameOptionIds();
+        deleteFiles(gameOptionIds);
+    }
+
+    private void deleteFiles(List<Long> gameOptionIds) {
+        List<File> files = fileRepository.findAllByResourceIdsAndFileType(gameOptionIds, GAME);
+        if (files.isEmpty()) {
+            return;
+        }
+        fileHandler.deleteFiles(files);
     }
 
     public List<GameSetResponse> findLatestGames(final String tagName) {

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -1,8 +1,10 @@
 package balancetalk.game.application;
 
+import static balancetalk.file.domain.FileType.GAME_OPTION;
+
 import balancetalk.bookmark.domain.GameBookmark;
+import balancetalk.file.domain.File;
 import balancetalk.file.domain.FileHandler;
-import balancetalk.file.domain.FileType;
 import balancetalk.file.domain.repository.FileRepository;
 import balancetalk.game.domain.Game;
 import balancetalk.game.domain.GameOption;
@@ -109,7 +111,7 @@ public class GameService {
                 fileRepository.findById(gameOptionDto.getFileId())
                         .ifPresent(
                                 file -> fileHandler.relocateFiles(Collections.singletonList(file), gameOption.getId(),
-                                        FileType.GAME_OPTION));
+                                        GAME_OPTION));
 
             }
         }
@@ -166,7 +168,7 @@ public class GameService {
     }
 
     private void deleteFiles(List<Long> gameOptionIds) {
-        List<File> files = fileRepository.findAllByResourceIdsAndFileType(gameOptionIds, GAME);
+        List<File> files = fileRepository.findAllByResourceIdsAndFileType(gameOptionIds, GAME_OPTION);
         if (files.isEmpty()) {
             return;
         }

--- a/src/main/java/balancetalk/game/domain/Game.java
+++ b/src/main/java/balancetalk/game/domain/Game.java
@@ -4,14 +4,26 @@ import balancetalk.global.common.BaseTimeEntity;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.vote.domain.VoteOption;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import java.util.stream.IntStream;
-import lombok.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -58,5 +70,9 @@ public class Game extends BaseTimeEntity {
         this.editedAt = LocalDateTime.now();
         IntStream.range(0, this.gameOptions.size())
                 .forEach(i -> this.gameOptions.get(i).updateOption(newGame.getGameOptions().get(i)));
+    }
+
+    public List<Long> getGameOptionIds() {
+        return gameOptions.stream().map(GameOption::getId).toList();
     }
 }

--- a/src/main/java/balancetalk/game/domain/GameSet.java
+++ b/src/main/java/balancetalk/game/domain/GameSet.java
@@ -139,6 +139,6 @@ public class GameSet extends BaseTimeEntity {
     }
 
     public List<Long> getGameOptionIds() {
-        return games.stream().flatMap(game -> game.getGameOptionIds().stream()).collect(Collectors.toList());
+        return games.stream().flatMap(game -> game.getGameOptionIds().stream()).toList();
     }
 }

--- a/src/main/java/balancetalk/game/domain/GameSet.java
+++ b/src/main/java/balancetalk/game/domain/GameSet.java
@@ -135,4 +135,8 @@ public class GameSet extends BaseTimeEntity {
     public String getFirstGameOptionImgB() {
         return games.get(0).getGameOptions().get(1).getImgUrl();
     }
+
+    public List<Long> getGameOptionIds() {
+        return games.stream().map(game -> game.getGameOptionIds()).toList();
+    }
 }

--- a/src/main/java/balancetalk/game/domain/GameSet.java
+++ b/src/main/java/balancetalk/game/domain/GameSet.java
@@ -21,7 +21,6 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -48,7 +47,7 @@ public class GameSet extends BaseTimeEntity {
     @NotBlank
     @Size(max = 50)
     private String title;
-    
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/balancetalk/game/domain/GameSet.java
+++ b/src/main/java/balancetalk/game/domain/GameSet.java
@@ -21,6 +21,7 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -138,6 +139,6 @@ public class GameSet extends BaseTimeEntity {
     }
 
     public List<Long> getGameOptionIds() {
-        return games.stream().map(game -> game.getGameOptionIds()).toList();
+        return games.stream().flatMap(game -> game.getGameOptionIds().stream()).collect(Collectors.toList());
     }
 }

--- a/src/main/java/balancetalk/global/config/SecurityConfig.java
+++ b/src/main/java/balancetalk/global/config/SecurityConfig.java
@@ -76,9 +76,28 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedOriginPattern("http://localhost:8080");
         configuration.addAllowedOriginPattern("http://localhost:3000"); // 프론트 쪽에서 허용
-        configuration.addAllowedOriginPattern("https://balancetalk.kro.kr"); // 도메인 주소
-        configuration.addExposedHeader("Authorization");
-        configuration.addExposedHeader("refreshToken");
+        configuration.addAllowedOriginPattern("https://pick0.com"); // 도메인 주소
+        configuration.addAllowedOriginPattern("https://api.pick0.com"); // 도메인 주소
+        configuration.addAllowedHeader("Accept");
+        configuration.addAllowedHeader("Authorization");
+        configuration.addAllowedHeader("refreshToken");
+        configuration.addAllowedHeader("accessToken");
+        configuration.addAllowedHeader("Content-Type");
+        configuration.addAllowedHeader("Origin");
+        configuration.addAllowedHeader("Cookie");
+        configuration.addAllowedHeader("X-Requested-With");
+        configuration.addAllowedHeader("Access-Control-Allow-Origin");
+        configuration.addAllowedHeader("Access-Control-Allow-Credentials");
+        configuration.addAllowedHeader("Access-Control-Allow-Methods");
+        configuration.addAllowedHeader("Access-Control-Allow-Headers");
+        configuration.addAllowedHeader("Host");
+        configuration.addAllowedHeader("Connection");
+        configuration.addAllowedHeader("Accept-Encoding");
+        configuration.addAllowedHeader("Accept-Language");
+        configuration.addAllowedHeader("Referer");
+        configuration.addAllowedHeader("User-Agent");
+        configuration.addAllowedHeader("Sec-Fetch-Mode");
+        configuration.addAllowedHeader("Sec-Fetch-Site");;
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE"));
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(MAX_AGE_SEC);

--- a/src/main/java/balancetalk/talkpick/application/TalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickService.java
@@ -95,5 +95,14 @@ public class TalkPickService {
         Member member = apiMember.toMember(memberRepository);
         TalkPick talkPick = member.getTalkPickById(talkPickId);
         talkPickRepository.delete(talkPick);
+        deleteFiles(talkPickId);
+    }
+
+    private void deleteFiles(Long talkPickId) {
+        List<File> files = fileRepository.findAllByResourceIdAndFileType(talkPickId, TALK_PICK);
+        if (files.isEmpty()) {
+            return;
+        }
+        fileHandler.deleteFiles(files);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 삭제 시 관련 이미지 파일도 삭제되도록 구현
- [x] 밸런스 게임 세트 삭제 시 관련 이미지 파일도 삭제되도록 구현

## 💡 자세한 설명
톡픽, 게임 등 리소스 제거 API 요청 시 관련 이미지 파일도 제거되도록 구현했습니다.

리소스는 제거되었지만 파일이 제거되지 않을 경우를 대비해, 추후 고아 객체 관리 로직 구현이 필요합니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #664 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
	- 파일 삭제 기능이 추가되어, `TalkPick` 삭제 시 관련 파일도 함께 삭제됩니다.
	- 특정 `resourceId`와 `fileType`에 따라 파일 목록을 검색할 수 있는 기능이 추가되었습니다.
	- `Game` 및 `GameSet` 클래스에 게임 옵션 ID를 가져오는 메서드가 추가되었습니다.
- **버그 수정**
	- 파일 삭제 과정에서 불필요한 작업을 방지하는 로직이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->