### PR TITLE
밸런스 게임 임시 저장 기능 구현

### DIFF
--- a/src/main/java/balancetalk/file/domain/FileType.java
+++ b/src/main/java/balancetalk/file/domain/FileType.java
@@ -4,7 +4,7 @@ public enum FileType {
     TALK_PICK("talks/", 10),
     TEMP_TALK_PICK("temp-talks/", 10),
     GAME_OPTION("game-options/", 1),
-    TEMP_GAME("temp-games/", 10),
+    TEMP_GAME_OPTION("temp-game-options/", 1),
     MEMBER("members/", 1);
 
     private final String uploadDir;

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
@@ -3,6 +3,7 @@ package balancetalk.file.domain.repository;
 import balancetalk.file.domain.File;
 import balancetalk.file.domain.FileType;
 import java.util.List;
+import java.util.Optional;
 
 public interface FileRepositoryCustom {
 
@@ -13,4 +14,6 @@ public interface FileRepositoryCustom {
     List<File> findAllByResourceIdAndFileType(Long resourceId, FileType fileType);
 
     List<File> findAllByResourceIdsAndFileType(List<Long> resourceIds, FileType fileType);
+
+    Optional<Long> findByResourceId(Long resourceId);
 }

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
@@ -3,7 +3,6 @@ package balancetalk.file.domain.repository;
 import balancetalk.file.domain.File;
 import balancetalk.file.domain.FileType;
 import java.util.List;
-import java.util.Optional;
 
 public interface FileRepositoryCustom {
 
@@ -15,5 +14,5 @@ public interface FileRepositoryCustom {
 
     List<File> findAllByResourceIdsAndFileType(List<Long> resourceIds, FileType fileType);
 
-    Optional<Long> findByResourceId(Long resourceId);
+    Long findByResourceIdAndFileType(Long resourceId, FileType fileType);
 }

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
@@ -14,5 +14,5 @@ public interface FileRepositoryCustom {
 
     List<File> findAllByResourceIdsAndFileType(List<Long> resourceIds, FileType fileType);
 
-    Long findByResourceIdAndFileType(Long resourceId, FileType fileType);
+    Long findIdByResourceIdAndFileType(Long resourceId, FileType fileType);
 }

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
@@ -6,7 +6,6 @@ import balancetalk.file.domain.File;
 import balancetalk.file.domain.FileType;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -50,12 +49,13 @@ public class FileRepositoryImpl implements FileRepositoryCustom {
     }
 
     @Override
-    public Optional<Long> findByResourceId(Long resourceId) {
-        return Optional.ofNullable(
-                queryFactory.select(file.id)
-                        .from(file)
-                        .where(file.resourceId.eq(resourceId))
-                        .fetchOne()
-        );
+    public Long findByResourceIdAndFileType(Long resourceId, FileType fileType) {
+        return queryFactory.select(file.id)
+                .from(file)
+                .where(
+                        file.resourceId.eq(resourceId),
+                        file.fileType.eq(fileType)
+                )
+                .fetchOne();
     }
 }

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
@@ -6,6 +6,7 @@ import balancetalk.file.domain.File;
 import balancetalk.file.domain.FileType;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -46,5 +47,15 @@ public class FileRepositoryImpl implements FileRepositoryCustom {
                 .from(file)
                 .where(file.fileType.eq(fileType), file.resourceId.in(resourceIds))
                 .fetch();
+    }
+
+    @Override
+    public Optional<Long> findByResourceId(Long resourceId) {
+        return Optional.ofNullable(
+                queryFactory.select(file.id)
+                        .from(file)
+                        .where(file.resourceId.eq(resourceId))
+                        .fetchOne()
+        );
     }
 }

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
@@ -49,7 +49,7 @@ public class FileRepositoryImpl implements FileRepositoryCustom {
     }
 
     @Override
-    public Long findByResourceIdAndFileType(Long resourceId, FileType fileType) {
+    public Long findIdByResourceIdAndFileType(Long resourceId, FileType fileType) {
         return queryFactory.select(file.id)
                 .from(file)
                 .where(

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -45,10 +45,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GameService {
 
-    private static final int PAGE_INITIAL_INDEX = 0;
-    private static final int PAGE_LIMIT = 16;
-    private static final int GAME_SIZE = 10;
-
     private final GameSetRepository gameSetRepository;
     private final MemberRepository memberRepository;
     private final MainTagRepository mainTagRepository;
@@ -60,14 +56,9 @@ public class GameService {
         Member member = apiMember.toMember(memberRepository);
         MainTag mainTag = mainTagRepository.findByName(request.getMainTag())
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_MAIN_TAG));
-        String title = request.getTitle();
 
         List<CreateOrUpdateGame> gameRequests = request.getGames();
-        if (gameRequests.size() < GAME_SIZE) {
-            throw new BalanceTalkException(ErrorCode.BALANCE_GAME_SIZE_TEN);
-        }
-
-        GameSet gameSet = request.toEntity(title, mainTag, member);
+        GameSet gameSet = request.toEntity(mainTag, member);
         List<Game> games = new ArrayList<>();
 
         for (CreateOrUpdateGame gameRequest : gameRequests) {

--- a/src/main/java/balancetalk/game/application/TempGameService.java
+++ b/src/main/java/balancetalk/game/application/TempGameService.java
@@ -36,37 +36,9 @@ public class TempGameService {
     @Transactional
     public void createTempGame(CreateTempGameSetRequest request, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
-        MainTag mainTag = mainTagRepository.findByName(request.getMainTag())
-                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_MAIN_TAG));
-
         if (member.hasTempGameSet()) {
-            TempGameSet tempGameSet = member.updateTempGameSet(request.toEntity(mainTag, member));
-            List<CreateTempGameRequest> tempGameRequests = request.getTempGames();
-            List<TempGame> tempGames = tempGameSet.getTempGames();
 
-            for (int i = 0; i < tempGameRequests.size(); i++) {
-                CreateTempGameRequest tempGameRequest = tempGameRequests.get(i);
-                List<File> files = fileRepository.findAllById(tempGameRequest.getFileIds());
-
-                TempGame tempGame = tempGames.get(i);
-                fileHandler.relocateFiles(files, tempGame.getId(), TEMP_GAME);
-            }
-            return;
         }
-
-        TempGameSet tempGameSet = request.toEntity(mainTag, member);
-        List<CreateTempGameRequest> tempGameRequests = request.getTempGames();
-        List<TempGame> tempGames = new ArrayList<>();
-
-        for (CreateTempGameRequest tempGameRequest : tempGameRequests) {
-            TempGame tempGame = tempGameRequest.toEntity();
-            tempGames.add(tempGame);
-            List<File> files = fileRepository.findAllById(tempGameRequest.getFileIds());
-            fileHandler.relocateFiles(files, tempGame.getId(), TEMP_GAME);
-        }
-
-        tempGameSet.addTempGames(tempGames);
-        tempGameSetRepository.save(tempGameSet);
     }
 
     public TempGameSetResponse findTempGameSet(ApiMember apiMember) {
@@ -74,6 +46,6 @@ public class TempGameService {
         TempGameSet tempGameSet = tempGameSetRepository.findByMember(member)
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME_SET));
 
-        return TempGameSetResponse.fromEntity(tempGameSet);
+        return null;
     }
 }

--- a/src/main/java/balancetalk/game/application/TempGameService.java
+++ b/src/main/java/balancetalk/game/application/TempGameService.java
@@ -1,16 +1,17 @@
 package balancetalk.game.application;
 
-import static balancetalk.file.domain.FileType.TEMP_GAME;
+import static balancetalk.file.domain.FileType.TEMP_GAME_OPTION;
 import static balancetalk.game.dto.TempGameDto.CreateTempGameRequest;
 
-import balancetalk.file.domain.File;
 import balancetalk.file.domain.FileHandler;
 import balancetalk.file.domain.repository.FileRepository;
 import balancetalk.game.domain.MainTag;
 import balancetalk.game.domain.TempGame;
+import balancetalk.game.domain.TempGameOption;
 import balancetalk.game.domain.TempGameSet;
 import balancetalk.game.domain.repository.MainTagRepository;
 import balancetalk.game.domain.repository.TempGameSetRepository;
+import balancetalk.game.dto.TempGameOptionDto.CreateTempGameOption;
 import balancetalk.game.dto.TempGameSetDto.CreateTempGameSetRequest;
 import balancetalk.game.dto.TempGameSetDto.TempGameSetResponse;
 import balancetalk.global.exception.BalanceTalkException;
@@ -18,7 +19,7 @@ import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
 import balancetalk.member.dto.ApiMember;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class TempGameService {
+
+    private static final int GAME_SIZE = 10;
+
     private final MemberRepository memberRepository;
     private final TempGameSetRepository tempGameSetRepository;
     private final FileRepository fileRepository;
@@ -36,8 +40,48 @@ public class TempGameService {
     @Transactional
     public void createTempGame(CreateTempGameSetRequest request, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
-        if (member.hasTempGameSet()) {
+        MainTag mainTag = mainTagRepository.findByName(request.getMainTag())
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_MAIN_TAG));
 
+        List<CreateTempGameRequest> tempGames = request.getTempGames();
+        if (tempGames.size() < GAME_SIZE) {
+            throw new BalanceTalkException(ErrorCode.BALANCE_GAME_SIZE_TEN);
+        }
+
+        List<TempGame> newTempGames = tempGames.stream()
+                .map(game -> game.toEntity(fileRepository))
+                .toList();
+
+        if (member.hasTempGameSet()) { // 기존 임시저장이 존재하는 경우
+            TempGameSet existGame = member.getTempGameSet();
+            existGame.updateTempGameSet(request.getTitle(), newTempGames);
+        }
+
+        else {
+            TempGameSet tempGameSet = request.toEntity(request.getTitle(), mainTag, member);
+            tempGameSetRepository.save(tempGameSet);
+        }
+        processTempGameFiles(tempGames, newTempGames);
+    }
+
+    private void processTempGameFiles(List<CreateTempGameRequest> requests, List<TempGame> tempGames) {
+        for (int i = 0; i < requests.size(); i++) {
+            CreateTempGameRequest gameRequest = requests.get(i);
+            TempGame tempGame = tempGames.get(i);
+
+            for (int j = 0; j < gameRequest.getTempGameOptions().size(); j++) {
+                CreateTempGameOption gameOptionDto = gameRequest.getTempGameOptions().get(j);
+                TempGameOption tempGameOption = tempGame.getTempGameOptions().get(j);
+
+                if (gameOptionDto.getFileId() == null) {
+                    continue;
+                }
+
+                fileRepository.findById(gameOptionDto.getFileId())
+                        .ifPresent(
+                                file -> fileHandler.relocateFiles(Collections.singletonList(file), tempGameOption.getId(),
+                                        TEMP_GAME_OPTION));
+            }
         }
     }
 

--- a/src/main/java/balancetalk/game/application/TempGameService.java
+++ b/src/main/java/balancetalk/game/application/TempGameService.java
@@ -48,9 +48,6 @@ public class TempGameService {
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_MAIN_TAG));
 
         List<CreateTempGameRequest> tempGames = request.getTempGames();
-        if (tempGames.size() < GAME_SIZE) {
-            throw new BalanceTalkException(ErrorCode.BALANCE_GAME_SIZE_TEN);
-        }
 
         List<TempGame> newTempGames = tempGames.stream()
                 .map(game -> game.toEntity(fileRepository))
@@ -64,7 +61,7 @@ public class TempGameService {
             return;
         }
 
-        TempGameSet tempGameSet = request.toEntity(request.getTitle(), mainTag, member);
+        TempGameSet tempGameSet = request.toEntity(mainTag, member);
         List<TempGame> games = new ArrayList<>();
 
         for (CreateTempGameRequest tempGame : tempGames) {

--- a/src/main/java/balancetalk/game/application/TempGameService.java
+++ b/src/main/java/balancetalk/game/application/TempGameService.java
@@ -85,7 +85,7 @@ public class TempGameService {
 
             List<TempGameOption> gameOptions = tempGame.getTempGameOptions();
 
-            for(int j = 0; j < tempGameOptions.size(); j++) {
+            for (int j = 0; j < tempGameOptions.size(); j++) {
                 TempGameOptionDto tempGameOptionDto = tempGameOptions.get(j);
                 TempGameOption tempGameOption = gameOptions.get(j);
 

--- a/src/main/java/balancetalk/game/application/TempGameService.java
+++ b/src/main/java/balancetalk/game/application/TempGameService.java
@@ -23,17 +23,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class TempGameService {
-
-    private static final int GAME_SIZE = 10;
-    private static final Logger log = LoggerFactory.getLogger(TempGameService.class);
 
     private final MemberRepository memberRepository;
     private final TempGameSetRepository tempGameSetRepository;
@@ -56,7 +51,6 @@ public class TempGameService {
         if (member.hasTempGameSet()) { // 기존 임시저장이 존재하는 경우
             TempGameSet existGame = member.getTempGameSet();
             existGame.updateTempGameSet(request.getTitle(), newTempGames);
-
             processTempGameFiles(tempGames, existGame.getTempGames());
             return;
         }

--- a/src/main/java/balancetalk/game/domain/TempGame.java
+++ b/src/main/java/balancetalk/game/domain/TempGame.java
@@ -11,19 +11,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.stream.IntStream;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -49,25 +46,14 @@ public class TempGame extends BaseTimeEntity {
 
     private LocalDateTime editedAt;
 
-    public void assignTempGameSet(TempGameSet tempGameSet) {
-        this.tempGameSet = tempGameSet;
-    }
-
     public void updateTempGame(TempGame newTempGame) {
-        // this.title = newTempGame.getTitle();
         this.description = newTempGame.getDescription();
-        Map<Long, TempGameOption> newTempGameOptions = new HashMap<>();
+        this.editedAt = LocalDateTime.now();
 
-        for (TempGameOption tempGameOption : tempGameOptions) {
-            newTempGameOptions.put(tempGameOption.getId(), tempGameOption);
-        }
-
-        tempGameOptions.forEach(option -> {
-            TempGameOption newOption = newTempGameOptions.get(option.getId());
-            if (newOption != null) {
-                option.update(newOption);
-                newTempGameOptions.remove(option.getId());
-            }
+        IntStream.range(0, newTempGame.getTempGameOptions().size()).forEach(i -> {
+            TempGameOption currentOption = this.tempGameOptions.get(i);
+            TempGameOption newOption = newTempGame.getTempGameOptions().get(i);
+            currentOption.updateTempGameOption(newOption);
         });
     }
 }

--- a/src/main/java/balancetalk/game/domain/TempGame.java
+++ b/src/main/java/balancetalk/game/domain/TempGame.java
@@ -55,4 +55,8 @@ public class TempGame extends BaseTimeEntity {
             currentOption.updateTempGameOption(newOption);
         });
     }
+
+    public List<Long> getGameOptionIds() {
+        return tempGameOptions.stream().map(TempGameOption::getId).toList();
+    }
 }

--- a/src/main/java/balancetalk/game/domain/TempGame.java
+++ b/src/main/java/balancetalk/game/domain/TempGame.java
@@ -12,7 +12,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -44,12 +43,12 @@ public class TempGame extends BaseTimeEntity {
     @Size(max = 100)
     private String description;
 
-    private LocalDateTime editedAt;
+    public void assignTempGameSet(TempGameSet tempGameSet) {
+        this.tempGameSet = tempGameSet;
+    }
 
     public void updateTempGame(TempGame newTempGame) {
         this.description = newTempGame.getDescription();
-        this.editedAt = LocalDateTime.now();
-
         IntStream.range(0, newTempGame.getTempGameOptions().size()).forEach(i -> {
             TempGameOption currentOption = this.tempGameOptions.get(i);
             TempGameOption newOption = newTempGame.getTempGameOptions().get(i);

--- a/src/main/java/balancetalk/game/domain/TempGame.java
+++ b/src/main/java/balancetalk/game/domain/TempGame.java
@@ -13,6 +13,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -43,23 +44,17 @@ public class TempGame extends BaseTimeEntity {
     private List<TempGameOption> tempGameOptions = new ArrayList<>();
 
     @NotBlank
-    @Size(max = 50)
-    private String title;
-
-    @NotBlank
     @Size(max = 100)
     private String description;
 
-    @PositiveOrZero
-    @ColumnDefault("0")
-    private Long bookmarks;
+    private LocalDateTime editedAt;
 
     public void assignTempGameSet(TempGameSet tempGameSet) {
         this.tempGameSet = tempGameSet;
     }
 
     public void updateTempGame(TempGame newTempGame) {
-        this.title = newTempGame.getTitle();
+        // this.title = newTempGame.getTitle();
         this.description = newTempGame.getDescription();
         Map<Long, TempGameOption> newTempGameOptions = new HashMap<>();
 

--- a/src/main/java/balancetalk/game/domain/TempGameOption.java
+++ b/src/main/java/balancetalk/game/domain/TempGameOption.java
@@ -35,8 +35,6 @@ public class TempGameOption {
     @Size(max = 30)
     private String name;
 
-    private Long fileId;
-
     @Size(max = 50)
     private String description;
 
@@ -52,7 +50,6 @@ public class TempGameOption {
     }
 
     public void updateTempGameOption (TempGameOption newTempGameOption){
-        this.fileId = newTempGameOption.getFileId();
         this.name = newTempGameOption.getName();
         this.description = newTempGameOption.getDescription();
     }

--- a/src/main/java/balancetalk/game/domain/TempGameOption.java
+++ b/src/main/java/balancetalk/game/domain/TempGameOption.java
@@ -53,14 +53,9 @@ public class TempGameOption {
     @JoinColumn(name = "temp_game_id")
     private TempGame tempGame;
 
-    public void addTempGame(TempGame tempGame) {
-        this.tempGame = tempGame;
-    }
-
-    public void update (TempGameOption newTempGameOption){
-        this.name = newTempGameOption.getName();
+    public void updateTempGameOption (TempGameOption newTempGameOption){
         this.imgUrl = newTempGameOption.getImgUrl();
+        this.name = newTempGameOption.getName();
         this.description = newTempGameOption.getDescription();
-        this.optionType = newTempGameOption.getOptionType();
     }
 }

--- a/src/main/java/balancetalk/game/domain/TempGameOption.java
+++ b/src/main/java/balancetalk/game/domain/TempGameOption.java
@@ -12,14 +12,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -37,7 +35,7 @@ public class TempGameOption {
     @Size(max = 30)
     private String name;
 
-    private String imgUrl;
+    private Long fileId;
 
     @Size(max = 50)
     private String description;
@@ -45,16 +43,16 @@ public class TempGameOption {
     @Enumerated(value = EnumType.STRING)
     private VoteOption optionType;
 
-    @PositiveOrZero
-    @ColumnDefault("0")
-    private long votesCount;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "temp_game_id")
     private TempGame tempGame;
 
+    public void assignTempGame(TempGame tempGame) {
+        this.tempGame = tempGame;
+    }
+
     public void updateTempGameOption (TempGameOption newTempGameOption){
-        this.imgUrl = newTempGameOption.getImgUrl();
+        this.fileId = newTempGameOption.getFileId();
         this.name = newTempGameOption.getName();
         this.description = newTempGameOption.getDescription();
     }

--- a/src/main/java/balancetalk/game/domain/TempGameOption.java
+++ b/src/main/java/balancetalk/game/domain/TempGameOption.java
@@ -49,7 +49,7 @@ public class TempGameOption {
         this.tempGame = tempGame;
     }
 
-    public void updateTempGameOption (TempGameOption newTempGameOption){
+    public void updateTempGameOption(TempGameOption newTempGameOption) {
         this.name = newTempGameOption.getName();
         this.description = newTempGameOption.getDescription();
     }

--- a/src/main/java/balancetalk/game/domain/TempGameOption.java
+++ b/src/main/java/balancetalk/game/domain/TempGameOption.java
@@ -12,12 +12,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -42,6 +44,10 @@ public class TempGameOption {
 
     @Enumerated(value = EnumType.STRING)
     private VoteOption optionType;
+
+    @PositiveOrZero
+    @ColumnDefault("0")
+    private long votesCount;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "temp_game_id")

--- a/src/main/java/balancetalk/game/domain/TempGameSet.java
+++ b/src/main/java/balancetalk/game/domain/TempGameSet.java
@@ -14,9 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -25,7 +23,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -54,23 +51,19 @@ public class TempGameSet extends BaseTimeEntity {
     @JoinColumn(name = "main_tag_id")
     private MainTag mainTag;
 
-    @PositiveOrZero
-    @ColumnDefault("0")
-    private long views;
-
     @Size(max = 10)
     private String subTag;
 
-    @PositiveOrZero
-    @ColumnDefault("0")
-    private Long bookmarks;
-
-    private LocalDateTime editedAt;
+    public void addGames(List<TempGame> tempGames) {
+        this.tempGames = tempGames;
+        tempGames.forEach(tempGame -> {
+            tempGame.assignTempGameSet(this);
+            tempGame.getTempGameOptions().forEach(option -> option.assignTempGame(tempGame));
+        });
+    }
 
     public void updateTempGameSet(String title, List<TempGame> newTempGames) {
         this.title = title;
-        this.editedAt = LocalDateTime.now();
-
         IntStream.range(0, this.tempGames.size()).forEach(i -> {
             TempGame existingGame = this.tempGames.get(i);
             TempGame newGame = newTempGames.get(i);

--- a/src/main/java/balancetalk/game/domain/TempGameSet.java
+++ b/src/main/java/balancetalk/game/domain/TempGameSet.java
@@ -19,6 +19,7 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -66,33 +67,14 @@ public class TempGameSet extends BaseTimeEntity {
 
     private LocalDateTime editedAt;
 
-    public void addTempGames(List<TempGame> tempGames) {
-        this.tempGames = tempGames;
-        tempGames.forEach(tempGame -> {
-            tempGame.assignTempGameSet(this);
-            tempGame.getTempGameOptions().forEach(tempGameOption -> tempGameOption.addTempGame(tempGame));
+    public void updateTempGameSet(String title, List<TempGame> newTempGames) {
+        this.title = title;
+        this.editedAt = LocalDateTime.now();
+
+        IntStream.range(0, this.tempGames.size()).forEach(i -> {
+            TempGame existingGame = this.tempGames.get(i);
+            TempGame newGame = newTempGames.get(i);
+            existingGame.updateTempGame(newGame);
         });
-    }
-
-
-    public TempGameSet updateTempGameSet(TempGameSet newTempGameSet) {
-        this.mainTag = newTempGameSet.getMainTag();
-        this.subTag = newTempGameSet.getSubTag();
-
-        List<TempGame> newTempGames = newTempGameSet.getTempGames();
-
-        newTempGames.forEach(newGame -> {
-            this.tempGames.stream()
-                    .filter(existingGame -> existingGame.getId().equals(newGame.getId()))
-                    .findFirst()
-                    .ifPresentOrElse(
-                            existingGame -> existingGame.updateTempGame(newGame),
-                            () -> {
-                                this.tempGames.add(newGame);
-                                newGame.assignTempGameSet(this);
-                            }
-                    );
-        });
-        return this;
     }
 }

--- a/src/main/java/balancetalk/game/domain/TempGameSet.java
+++ b/src/main/java/balancetalk/game/domain/TempGameSet.java
@@ -13,8 +13,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -39,6 +41,10 @@ public class TempGameSet extends BaseTimeEntity {
     @OneToMany(mappedBy = "tempGameSet", cascade = CascadeType.ALL)
     private List<TempGame> tempGames = new ArrayList<>();
 
+    @NotBlank
+    @Size(max = 50)
+    private String title;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -53,6 +59,12 @@ public class TempGameSet extends BaseTimeEntity {
 
     @Size(max = 10)
     private String subTag;
+
+    @PositiveOrZero
+    @ColumnDefault("0")
+    private Long bookmarks;
+
+    private LocalDateTime editedAt;
 
     public void addTempGames(List<TempGame> tempGames) {
         this.tempGames = tempGames;

--- a/src/main/java/balancetalk/game/dto/GameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/GameSetDto.java
@@ -6,6 +6,8 @@ import balancetalk.game.domain.GameSet;
 import balancetalk.game.domain.MainTag;
 import balancetalk.game.dto.GameDto.CreateOrUpdateGame;
 import balancetalk.game.dto.GameDto.GameDetailResponse;
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,6 +24,8 @@ public class GameSetDto {
     @Data
     public static class CreateGameSetRequest {
 
+        private static final int GAME_SIZE = 10;
+
         @Schema(description = "밸런스게임 세트 제목", example = "밸런스게임 세트 제목")
         private String title;
 
@@ -33,7 +37,11 @@ public class GameSetDto {
 
         private List<CreateOrUpdateGame> games;
 
-        public GameSet toEntity(String title, MainTag mainTag, Member member) {
+        public GameSet toEntity(MainTag mainTag, Member member) {
+            if (games == null || games.size() < GAME_SIZE) {
+                throw new BalanceTalkException(ErrorCode.BALANCE_GAME_SIZE_TEN);
+            }
+
             return GameSet.builder()
                     .title(title)
                     .mainTag(mainTag)

--- a/src/main/java/balancetalk/game/dto/TempGameDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameDto.java
@@ -1,5 +1,6 @@
 package balancetalk.game.dto;
 
+import balancetalk.file.domain.FileType;
 import balancetalk.file.domain.repository.FileRepository;
 import balancetalk.game.domain.TempGame;
 import balancetalk.game.domain.TempGameOption;
@@ -48,7 +49,7 @@ public class TempGameDto {
         public static TempGameResponse fromEntity(TempGame tempGame, FileRepository fileRepository) {
             List<TempGameOptionDto> tempGameOptions = tempGame.getTempGameOptions().stream()
                     .map(option -> {
-                        Long fileId = fileRepository.findByResourceId(option.getId()).orElse(null);
+                        Long fileId = fileRepository.findByResourceIdAndFileType(option.getId(), FileType.TEMP_GAME_OPTION);
                         return TempGameOptionDto.fromEntity(option, fileId);
                     })
                     .toList();

--- a/src/main/java/balancetalk/game/dto/TempGameDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameDto.java
@@ -1,9 +1,13 @@
 package balancetalk.game.dto;
 
+import balancetalk.file.domain.repository.FileRepository;
+import balancetalk.game.domain.GameOption;
 import balancetalk.game.domain.TempGame;
+import balancetalk.game.domain.TempGameOption;
 import balancetalk.game.dto.TempGameOptionDto.CreateTempGameOption;
 import balancetalk.game.dto.TempGameOptionDto.FindTempGameOption;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,20 +21,20 @@ public class TempGameDto {
     @Schema(description = "임시 밸런스 게임 저장 요청")
     public static class CreateTempGameRequest {
 
-        @Schema(description = "제목", example = "제목")
-        private String title;
-
         @Schema(description = "게임 추가 설명", example = "추가 설명")
         private String description;
 
         private List<CreateTempGameOption> tempGameOptions;
 
-        public TempGame toEntity() {
+        public TempGame toEntity(FileRepository fileRepository) {
+            List<TempGameOption> options = tempGameOptions.stream()
+                    .map(option -> option.toEntity(fileRepository))
+                    .toList();
+
             return TempGame.builder()
-                    .title(title)
                     .description(description)
-                    .tempGameOptions(tempGameOptions.stream().map(CreateTempGameOption::toEntity).toList())
-                    .bookmarks(0L)
+                    .tempGameOptions(options)
+                    .editedAt(LocalDateTime.now())
                     .build();
         }
 
@@ -41,27 +45,26 @@ public class TempGameDto {
         }
     }
 
-    @Data
-    @Builder
-    @AllArgsConstructor
-    @Schema(description = "임시 밸런스 게임 상세 조회 응답")
-    public static class TempGameDetailResponse {
-
-        @Schema(description = "밸런스 게임 제목", example = "제목")
-        private String title;
-
-        @Schema(description = "게임 추가 설명", example = "추가 설명")
-        private String description;
-
-        private List<FindTempGameOption> tempGameOptions;
-
-        public static TempGameDetailResponse fromEntity(TempGame tempGame) {
-            return TempGameDetailResponse.builder()
-                    .title(tempGame.getTitle())
-                    .description(tempGame.getDescription())
-                    .tempGameOptions(tempGame.getTempGameOptions().stream().map(FindTempGameOption::fromEntity).toList())
-                    .build();
-        }
-    }
+//    @Data
+//    @Builder
+//    @AllArgsConstructor
+//    @Schema(description = "임시 밸런스 게임 상세 조회 응답")
+//    public static class TempGameDetailResponse {
+//
+//
+//
+//        @Schema(description = "게임 추가 설명", example = "추가 설명")
+//        private String description;
+//
+//        private List<FindTempGameOption> tempGameOptions;
+//
+//        public static TempGameDetailResponse fromEntity(TempGame tempGame) {
+//            return TempGameDetailResponse.builder()
+//                    .title(tempGame.getTitle())
+//                    .description(tempGame.getDescription())
+//                    .tempGameOptions(tempGame.getTempGameOptions().stream().map(FindTempGameOption::fromEntity).toList())
+//                    .build();
+//        }
+//    }
 
 }

--- a/src/main/java/balancetalk/game/dto/TempGameDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameDto.java
@@ -1,13 +1,9 @@
 package balancetalk.game.dto;
 
 import balancetalk.file.domain.repository.FileRepository;
-import balancetalk.game.domain.GameOption;
 import balancetalk.game.domain.TempGame;
 import balancetalk.game.domain.TempGameOption;
-import balancetalk.game.dto.TempGameOptionDto.CreateTempGameOption;
-import balancetalk.game.dto.TempGameOptionDto.FindTempGameOption;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +20,7 @@ public class TempGameDto {
         @Schema(description = "게임 추가 설명", example = "추가 설명")
         private String description;
 
-        private List<CreateTempGameOption> tempGameOptions;
+        private List<TempGameOptionDto> tempGameOptions;
 
         public TempGame toEntity(FileRepository fileRepository) {
             List<TempGameOption> options = tempGameOptions.stream()
@@ -34,37 +30,30 @@ public class TempGameDto {
             return TempGame.builder()
                     .description(description)
                     .tempGameOptions(options)
-                    .editedAt(LocalDateTime.now())
                     .build();
-        }
-
-        public List<Long> getFileIds() {
-            return this.tempGameOptions.stream()
-                    .map(CreateTempGameOption::getFileId)
-                    .toList();
         }
     }
 
-//    @Data
-//    @Builder
-//    @AllArgsConstructor
-//    @Schema(description = "임시 밸런스 게임 상세 조회 응답")
-//    public static class TempGameDetailResponse {
-//
-//
-//
-//        @Schema(description = "게임 추가 설명", example = "추가 설명")
-//        private String description;
-//
-//        private List<FindTempGameOption> tempGameOptions;
-//
-//        public static TempGameDetailResponse fromEntity(TempGame tempGame) {
-//            return TempGameDetailResponse.builder()
-//                    .title(tempGame.getTitle())
-//                    .description(tempGame.getDescription())
-//                    .tempGameOptions(tempGame.getTempGameOptions().stream().map(FindTempGameOption::fromEntity).toList())
-//                    .build();
-//        }
-//    }
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "임시 밸런스 게임 응답")
+    public static class TempGameResponse {
 
+        @Schema(description = "게임 추가 설명", example = "추가 설명")
+        private String description;
+
+        private List<TempGameOptionDto> tempGameOptions;
+
+        public static TempGameResponse fromEntity(TempGame tempGame) {
+            List<TempGameOptionDto> tempGameOptions = tempGame.getTempGameOptions().stream()
+                    .map(TempGameOptionDto::fromEntity)
+                    .toList();
+
+            return TempGameResponse.builder()
+                    .description(tempGame.getDescription())
+                    .tempGameOptions(tempGameOptions)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/balancetalk/game/dto/TempGameDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameDto.java
@@ -45,9 +45,12 @@ public class TempGameDto {
 
         private List<TempGameOptionDto> tempGameOptions;
 
-        public static TempGameResponse fromEntity(TempGame tempGame) {
+        public static TempGameResponse fromEntity(TempGame tempGame, FileRepository fileRepository) {
             List<TempGameOptionDto> tempGameOptions = tempGame.getTempGameOptions().stream()
-                    .map(TempGameOptionDto::fromEntity)
+                    .map(option -> {
+                        Long fileId = fileRepository.findByResourceId(option.getId()).orElse(null);
+                        return TempGameOptionDto.fromEntity(option, fileId);
+                    })
                     .toList();
 
             return TempGameResponse.builder()

--- a/src/main/java/balancetalk/game/dto/TempGameDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameDto.java
@@ -49,7 +49,7 @@ public class TempGameDto {
         public static TempGameResponse fromEntity(TempGame tempGame, FileRepository fileRepository) {
             List<TempGameOptionDto> tempGameOptions = tempGame.getTempGameOptions().stream()
                     .map(option -> {
-                        Long fileId = fileRepository.findByResourceIdAndFileType(
+                        Long fileId = fileRepository.findIdByResourceIdAndFileType(
                                 option.getId(), FileType.TEMP_GAME_OPTION);
                         return TempGameOptionDto.fromEntity(option, fileId);
                     })

--- a/src/main/java/balancetalk/game/dto/TempGameDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameDto.java
@@ -49,7 +49,8 @@ public class TempGameDto {
         public static TempGameResponse fromEntity(TempGame tempGame, FileRepository fileRepository) {
             List<TempGameOptionDto> tempGameOptions = tempGame.getTempGameOptions().stream()
                     .map(option -> {
-                        Long fileId = fileRepository.findByResourceIdAndFileType(option.getId(), FileType.TEMP_GAME_OPTION);
+                        Long fileId = fileRepository.findByResourceIdAndFileType(
+                                option.getId(), FileType.TEMP_GAME_OPTION);
                         return TempGameOptionDto.fromEntity(option, fileId);
                     })
                     .toList();

--- a/src/main/java/balancetalk/game/dto/TempGameOptionDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameOptionDto.java
@@ -1,6 +1,11 @@
 package balancetalk.game.dto;
 
+import balancetalk.file.domain.File;
+import balancetalk.file.domain.repository.FileRepository;
+import balancetalk.game.domain.GameOption;
 import balancetalk.game.domain.TempGameOption;
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.exception.ErrorCode;
 import balancetalk.vote.domain.VoteOption;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -28,10 +33,16 @@ public class TempGameOptionDto {
         @Schema(description = "선택지", example = "A")
         private VoteOption optionType;
 
-        public TempGameOption toEntity() {
+        public TempGameOption toEntity(FileRepository fileRepository) {
+            String newImgUrl = null;
+            if (fileId != null) {
+                File file = fileRepository.findById(fileId)
+                        .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
+                newImgUrl = file.getS3Url();
+            }
             return TempGameOption.builder()
                     .name(name)
-                    .imgUrl(imgUrl)
+                    .imgUrl(newImgUrl)
                     .description(description)
                     .optionType(optionType)
                     .build();

--- a/src/main/java/balancetalk/game/dto/TempGameOptionDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameOptionDto.java
@@ -2,77 +2,56 @@ package balancetalk.game.dto;
 
 import balancetalk.file.domain.File;
 import balancetalk.file.domain.repository.FileRepository;
-import balancetalk.game.domain.GameOption;
 import balancetalk.game.domain.TempGameOption;
 import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.vote.domain.VoteOption;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
+
+@Data
+@Builder
+@AllArgsConstructor
+@Schema(description = "임시 밸런스 게임 선택지")
 public class TempGameOptionDto {
 
-    @Data
-    @Builder
-    @Schema(description = "밸런스 게임 옵션 생성 요청")
-    public static class CreateTempGameOption {
+    @Schema(description = "선택지 이름", example = "선택지 이름")
+    private String name;
 
-        @Schema(description = "선택지 이름", example = "선택지 이름")
-        private String name;
+    @Schema(description = "선택지 이미지 파일 ID", example = "12")
+    private Long fileId;
 
-        @Schema(description = "선택지 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/067cc56e-21b7-468f-a2c1-4839036ee7cd_unnamed.png")
-        private String imgUrl;
+    @Schema(description = "선택지 추가설명", example = "선택지 추가 설명")
+    private String description;
 
-        @Schema(description = "선택지 이미지 파일 ID", example = "12")
-        private Long fileId;
+    @Schema(description = "선택지", example = "A")
+    private VoteOption optionType;
 
-        @Schema(description = "선택지 추가설명", example = "선택지 추가 설명")
-        private String description;
-
-        @Schema(description = "선택지", example = "A")
-        private VoteOption optionType;
-
-        public TempGameOption toEntity(FileRepository fileRepository) {
-            String newImgUrl = null;
-            if (fileId != null) {
-                File file = fileRepository.findById(fileId)
-                        .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
-                newImgUrl = file.getS3Url();
-            }
-            return TempGameOption.builder()
-                    .name(name)
-                    .imgUrl(newImgUrl)
-                    .description(description)
-                    .optionType(optionType)
-                    .build();
+    public TempGameOption toEntity(FileRepository fileRepository) {
+        Long newFileId = null;
+        if (fileId != null) {
+            File file = fileRepository.findById(fileId)
+                    .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
+            newFileId = file.getId();
         }
+        
+        return TempGameOption.builder()
+                .name(name)
+                .fileId(newFileId)
+                .description(description)
+                .optionType(optionType)
+                .build();
     }
 
-    @Data
-    @Builder
-    @Schema(description = "밸런스 게임 옵션 조회 응답")
-    public static class FindTempGameOption {
-
-        @Schema(description = "선택지 이름", example = "선택지 이름")
-        private String name;
-
-        @Schema(description = "선택지 추가설명", example = "선택지 추가 설명")
-        private String description;
-
-        @Schema(description = "선택지 이미지", example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/067cc56e-21b7-468f-a2c1-4839036ee7cd_unnamed.png")
-        private String imgUrl;
-
-        @Schema(description = "선택지", example = "A")
-        private VoteOption optionType;
-
-        public static FindTempGameOption fromEntity(TempGameOption tempGameOption) {
-            return FindTempGameOption.builder()
-                    .name(tempGameOption.getName())
-                    .imgUrl(tempGameOption.getImgUrl())
-                    .description(tempGameOption.getDescription())
-                    .optionType(tempGameOption.getOptionType())
-                    .build();
-        }
+    public static TempGameOptionDto fromEntity(TempGameOption tempGameOption) {
+        return TempGameOptionDto.builder()
+                .name(tempGameOption.getName())
+                .fileId(tempGameOption.getFileId())
+                .description(tempGameOption.getDescription())
+                .optionType(tempGameOption.getOptionType())
+                .build();
     }
 }

--- a/src/main/java/balancetalk/game/dto/TempGameOptionDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameOptionDto.java
@@ -31,25 +31,23 @@ public class TempGameOptionDto {
     private VoteOption optionType;
 
     public TempGameOption toEntity(FileRepository fileRepository) {
-        Long newFileId = null;
         if (fileId != null) {
-            File file = fileRepository.findById(fileId)
+            fileRepository.findById(fileId)
                     .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
-            newFileId = file.getId();
         }
 
         return TempGameOption.builder()
                 .name(name)
-                .fileId(newFileId)
                 .description(description)
                 .optionType(optionType)
                 .build();
     }
 
-    public static TempGameOptionDto fromEntity(TempGameOption tempGameOption) {
+    public static TempGameOptionDto fromEntity(TempGameOption tempGameOption, Long fileId) {
+
         return TempGameOptionDto.builder()
                 .name(tempGameOption.getName())
-                .fileId(tempGameOption.getFileId())
+                .fileId(fileId)
                 .description(tempGameOption.getDescription())
                 .optionType(tempGameOption.getOptionType())
                 .build();

--- a/src/main/java/balancetalk/game/dto/TempGameOptionDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameOptionDto.java
@@ -31,9 +31,8 @@ public class TempGameOptionDto {
     private VoteOption optionType;
 
     public TempGameOption toEntity(FileRepository fileRepository) {
-        if (fileId != null) {
-            fileRepository.findById(fileId)
-                    .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
+        if (fileId != null && !fileRepository.existsById(fileId)) {
+            throw new BalanceTalkException(ErrorCode.NOT_FOUND_FILE);
         }
 
         return TempGameOption.builder()

--- a/src/main/java/balancetalk/game/dto/TempGameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameSetDto.java
@@ -1,5 +1,6 @@
 package balancetalk.game.dto;
 
+import balancetalk.game.domain.MainTag;
 import balancetalk.game.domain.TempGameSet;
 import balancetalk.game.dto.TempGameDto.CreateTempGameRequest;
 import balancetalk.member.domain.Member;
@@ -17,11 +18,19 @@ public class TempGameSetDto {
         @Schema(description = "밸런스게임 세트 제목", example = "밸런스게임 세트 제목")
         private String title;
 
+        @Schema(description = "밸런스 게임 메인 태그", example = "커플")
+        private String mainTag;
+
+        @Schema(description = "밸런스 게임 서브 태그", example = "커플지옥")
+        private String subTag;
+
         private List<CreateTempGameRequest> tempGames;
 
-        public TempGameSet toEntity(String title, Member member) {
+        public TempGameSet toEntity(String title, MainTag mainTag, Member member) {
             return TempGameSet.builder()
                     .title(title)
+                    .mainTag(mainTag)
+                    .subTag(subTag)
                     .member(member)
                     .bookmarks(0L)
                     .editedAt(LocalDateTime.now())

--- a/src/main/java/balancetalk/game/dto/TempGameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameSetDto.java
@@ -1,11 +1,10 @@
 package balancetalk.game.dto;
 
-import balancetalk.game.domain.MainTag;
 import balancetalk.game.domain.TempGameSet;
 import balancetalk.game.dto.TempGameDto.CreateTempGameRequest;
-import balancetalk.game.dto.TempGameDto.TempGameDetailResponse;
 import balancetalk.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
@@ -15,20 +14,17 @@ public class TempGameSetDto {
     @Data
     public static class CreateTempGameSetRequest {
 
-        @Schema(description = "밸런스 게임 메인 태그", example = "커플")
-        private String mainTag;
-
-        @Schema(description = "밸런스 게임 서브 태그", example = "커플지옥")
-        private String subTag;
+        @Schema(description = "밸런스게임 세트 제목", example = "밸런스게임 세트 제목")
+        private String title;
 
         private List<CreateTempGameRequest> tempGames;
 
-        public TempGameSet toEntity(MainTag mainTag, Member member) {
+        public TempGameSet toEntity(String title, Member member) {
             return TempGameSet.builder()
-                    .mainTag(mainTag)
-                    .subTag(subTag)
-                    .tempGames(tempGames.stream().map(CreateTempGameRequest::toEntity).toList())
+                    .title(title)
                     .member(member)
+                    .bookmarks(0L)
+                    .editedAt(LocalDateTime.now())
                     .build();
         }
     }
@@ -38,13 +34,5 @@ public class TempGameSetDto {
     @Schema(description = "임시 밸런스 게임 세트 조회 응답")
     public static class TempGameSetResponse {
 
-        private List<TempGameDetailResponse> tempGameDetailResponses;
-
-        public static TempGameSetResponse fromEntity(TempGameSet tempGameSet) {
-            return TempGameSetResponse.builder()
-                    .tempGameDetailResponses(tempGameSet.getTempGames().stream()
-                            .map(TempGameDetailResponse::fromEntity).toList()
-                    ).build();
-        }
     }
 }

--- a/src/main/java/balancetalk/game/dto/TempGameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameSetDto.java
@@ -5,6 +5,8 @@ import balancetalk.game.domain.MainTag;
 import balancetalk.game.domain.TempGameSet;
 import balancetalk.game.dto.TempGameDto.CreateTempGameRequest;
 import balancetalk.game.dto.TempGameDto.TempGameResponse;
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -13,6 +15,8 @@ import lombok.Builder;
 import lombok.Data;
 
 public class TempGameSetDto {
+
+    private static final int GAME_SIZE = 10;
 
     @Data
     public static class CreateTempGameSetRequest {
@@ -28,7 +32,10 @@ public class TempGameSetDto {
 
         private List<CreateTempGameRequest> tempGames;
 
-        public TempGameSet toEntity(String title, MainTag mainTag, Member member) {
+        public TempGameSet toEntity(MainTag mainTag, Member member) {
+            if (tempGames == null || tempGames.size() < GAME_SIZE) {
+                throw new BalanceTalkException(ErrorCode.BALANCE_GAME_SIZE_TEN);
+            }
             return TempGameSet.builder()
                     .title(title)
                     .mainTag(mainTag)

--- a/src/main/java/balancetalk/game/dto/TempGameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameSetDto.java
@@ -1,5 +1,6 @@
 package balancetalk.game.dto;
 
+import balancetalk.file.domain.repository.FileRepository;
 import balancetalk.game.domain.MainTag;
 import balancetalk.game.domain.TempGameSet;
 import balancetalk.game.dto.TempGameDto.CreateTempGameRequest;
@@ -55,10 +56,10 @@ public class TempGameSetDto {
         @Schema(description = "게임 리스트")
         private List<TempGameResponse> tempGames;
 
-        public static TempGameSetResponse fromEntity(TempGameSet tempGameSet) {
+        public static TempGameSetResponse fromEntity(TempGameSet tempGameSet, FileRepository fileRepository) {
 
             List<TempGameResponse> tempGames = tempGameSet.getTempGames().stream()
-                    .map(tempGame -> TempGameResponse.fromEntity(tempGame))
+                    .map(tempGame -> TempGameResponse.fromEntity(tempGame, fileRepository))
                     .toList();
 
             return TempGameSetResponse.builder()

--- a/src/main/java/balancetalk/game/dto/TempGameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameSetDto.java
@@ -3,10 +3,11 @@ package balancetalk.game.dto;
 import balancetalk.game.domain.MainTag;
 import balancetalk.game.domain.TempGameSet;
 import balancetalk.game.dto.TempGameDto.CreateTempGameRequest;
+import balancetalk.game.dto.TempGameDto.TempGameResponse;
 import balancetalk.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
@@ -32,16 +33,41 @@ public class TempGameSetDto {
                     .mainTag(mainTag)
                     .subTag(subTag)
                     .member(member)
-                    .bookmarks(0L)
-                    .editedAt(LocalDateTime.now())
                     .build();
         }
     }
 
     @Data
     @Builder
+    @AllArgsConstructor
     @Schema(description = "임시 밸런스 게임 세트 조회 응답")
     public static class TempGameSetResponse {
+
+        @Schema(description = "밸런스게임 세트 제목", example = "밸런스게임 세트 제목")
+        private String title;
+
+        @Schema(description = "밸런스 게임 메인 태그", example = "커플")
+        private String mainTag;
+
+        @Schema(description = "밸런스 게임 서브 태그", example = "커플지옥")
+        private String subTag;
+
+        @Schema(description = "게임 리스트")
+        private List<TempGameResponse> tempGames;
+
+        public static TempGameSetResponse fromEntity(TempGameSet tempGameSet) {
+
+            List<TempGameResponse> tempGames = tempGameSet.getTempGames().stream()
+                    .map(tempGame -> TempGameResponse.fromEntity(tempGame))
+                    .toList();
+
+            return TempGameSetResponse.builder()
+                    .title(tempGameSet.getTitle())
+                    .mainTag(tempGameSet.getMainTag().getName())
+                    .subTag(tempGameSet.getSubTag())
+                    .tempGames(tempGames)
+                    .build();
+        }
 
     }
 }

--- a/src/main/java/balancetalk/game/dto/TempGameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameSetDto.java
@@ -9,6 +9,7 @@ import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,12 +23,14 @@ public class TempGameSetDto {
     public static class CreateTempGameSetRequest {
 
         @Schema(description = "밸런스게임 세트 제목", example = "밸런스게임 세트 제목")
+        @Size(max = 50, message = "제목은 최대 50자까지 입력 가능합니다")
         private String title;
 
         @Schema(description = "밸런스 게임 메인 태그", example = "커플")
         private String mainTag;
 
         @Schema(description = "밸런스 게임 서브 태그", example = "커플지옥")
+        @Size(max = 10, message = "서브 태그는 최대 10자까지 입력 가능합니다")
         private String subTag;
 
         private List<CreateTempGameRequest> tempGames;

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -105,7 +105,6 @@ public enum ErrorCode {
     ALREADY_REPORTED_POST(CONFLICT, "이미 신고한 게시글 입니다."),
     ALREADY_REPORTED_COMMENT(CONFLICT, "이미 신고한 댓글 입니다."),
     SAME_VOTE(CONFLICT, "변경하려는 선택지가 이전과 동일합니다."),
-    ALREADY_REGISTERED_FILE(CONFLICT, "이미 등록된 파일입니다."),
 
     // 500
     REDIS_CONNECTION_FAIL(INTERNAL_SERVER_ERROR, "Redis 연결에 실패했습니다."),

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -105,7 +105,7 @@ public enum ErrorCode {
     ALREADY_REPORTED_POST(CONFLICT, "이미 신고한 게시글 입니다."),
     ALREADY_REPORTED_COMMENT(CONFLICT, "이미 신고한 댓글 입니다."),
     SAME_VOTE(CONFLICT, "변경하려는 선택지가 이전과 동일합니다."),
-    ALREADY_REGISTERED_FILE(CONFLICT,"이미 등록된 파일입니다."),
+    ALREADY_REGISTERED_FILE(CONFLICT, "이미 등록된 파일입니다."),
 
     // 500
     REDIS_CONNECTION_FAIL(INTERNAL_SERVER_ERROR, "Redis 연결에 실패했습니다."),

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -127,7 +127,7 @@ public class Member extends BaseTimeEntity {
     public boolean hasVotedGame(Game game) {
         return gameVotes.stream()
                 .anyMatch(vote -> game.getGameOptions().stream()
-                        .anyMatch(gameOption -> vote.matchesGameOption(gameOption)));
+                        .anyMatch(vote::matchesGameOption));
     }
 
     public boolean isMyTalkPick(TalkPick talkPick) {
@@ -174,10 +174,6 @@ public class Member extends BaseTimeEntity {
 
     public Long updateTempTalkPick(TempTalkPick newTempTalkPick) {
         return tempTalkPick.update(newTempTalkPick);
-    }
-
-    public TempGameSet updateTempGameSet(TempGameSet newTempGameSet) {
-        return tempGameSet.updateTempGameSet(newTempGameSet);
     }
 
     public int getPostsCount() {


### PR DESCRIPTION
## 💡 작업 내용
- [x] 임시 저장 기능 구현
- [x] 임시 저장 후 불러오기 기능 구현
- [x] Temp_Game_Option Entity에서 파일 필드 제거

## 💡 자세한 설명

임시 저장 기능같은 경우, 회원이 이미 임시저장한 게시글이 있는 경우엔

![스크린샷 2024-11-14 오후 7 57 02](https://github.com/user-attachments/assets/a51c4ebe-44f9-437a-8114-9f1a6e1e2c7d)

기존의 임시 저장한 게시글에 업데이트를 해서 저장하도록 구현했습니다.

![스크린샷 2024-11-14 오후 8 01 46](https://github.com/user-attachments/assets/58e63051-7614-4f5e-b93f-bf0ff24f6dff)

처음 저장하는 경우, 연관 관계 메서드를 통해 DB에 save 해주도록 구현했습니다.

![스크린샷 2024-11-19 오후 10 24 50](https://github.com/user-attachments/assets/c210ae63-70ed-4ec1-a06e-d440e155585d)

임시 불러오기를 하는 경우, 그대로 복사해서 밸런스 게임 생성해주면 됩니다. 하지만 현재 `tempGames` , `tempGameOptions`를`games`, `gameOptions`로 변경을 해야 밸런스 게임 생성이 가능한데 해당 바꾸는 작업을 백쪽에서 해야할지 프론트로 넘겨줘야할지 고민입니다.




## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #701 #686 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- `TEMP_GAME` 상수를 `TEMP_GAME_OPTION`으로 변경하고 관련된 문자열 및 정수 값을 업데이트했습니다.
	- 파일 ID와 파일 유형에 따라 파일 ID를 검색할 수 있는 새로운 메서드 추가.
	- `TempGameSet`에 제목 필드 추가 및 유효성 검사 로직 개선.
  
- **Bug Fixes**
	- `hasVotedGame` 메서드의 로직 간소화.

- **Refactor**
	- 여러 클래스에서 필드 및 메서드 이름 변경으로 가독성 향상.
	- `TempGame` 및 `TempGameOption` 클래스에서 불필요한 필드 제거.

- **Documentation**
	- API 문서화를 위한 새로운 주석 추가 및 기존 주석 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->