### PR TITLE
밸런스게임 URI 변경 (스웨거) 완료

### DIFF
--- a/src/main/java/balancetalk/game/presentation/SearchGameController.java
+++ b/src/main/java/balancetalk/game/presentation/SearchGameController.java
@@ -20,7 +20,7 @@ public class SearchGameController {
     private final SearchGameService searchGameService;
 
     @Operation(summary = "밸런스게임 검색", description = "밸런스게임을 검색합니다. (정렬 기준 : views, createdAt)")
-    @GetMapping("/search/game")
+    @GetMapping("/search/game-sets")
     public Page<SearchGameResponse> searchTalkPicks(@RequestParam("query") String query,
                                                     @RequestParam(defaultValue = "0") int page,
                                                     @RequestParam(defaultValue = "9", required = false) int size,

--- a/src/main/java/balancetalk/member/presentation/MyPageController.java
+++ b/src/main/java/balancetalk/member/presentation/MyPageController.java
@@ -68,7 +68,7 @@ public class MyPageController {
         return myPageService.findAllTalkPicksByMember(apiMember, pageable);
     }
 
-    @GetMapping("/games/bookmarks")
+    @GetMapping("/game-sets/bookmarks")
     @Operation(summary = "북마크한 밸런스 게임 목록 조회", description = "로그인한 회원이 북마크한 밸런스 게임 목록을 조회한다.")
     public Page<GameMyPageResponse> findAllBookmarkedGames(
             @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "6", required = false) int size,
@@ -78,7 +78,7 @@ public class MyPageController {
         return myPageService.findAllBookmarkedGames(apiMember, pageable);
     }
 
-    @GetMapping("/games/votes")
+    @GetMapping("/game-sets/votes")
     @Operation(summary = "투표한 밸런스 게임 목록 조회", description = "로그인한 회원이 투표한 밸런스 게임 목록을 조회한다.")
     public Page<GameMyPageResponse> findAllVotedGames(
             @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "6", required = false) int size,
@@ -88,7 +88,7 @@ public class MyPageController {
         return myPageService.findAllVotedGames(apiMember, pageable);
     }
 
-    @GetMapping("/games/written")
+    @GetMapping("/game-sets/written")
     @Operation(summary = "내가 작성한 밸런스 게임 목록 조회", description = "로그인한 회원이 작성한 밸런스 게임 목록을 조회한다.")
     public Page<GameMyPageResponse> findAllMyGames(
             @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "6", required = false) int size,


### PR DESCRIPTION
## 💡 작업 내용
- [x] 마이페이지의 `game` -> `game-sets` URI 변경
- [x] 밸런스게임 검색의 `game` -> `game-sets` URI 변경

## 💡 자세한 설명
통일성 있는 URI를 위해 URI를 변경했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #697


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 게임 검색 기능의 URL 경로가 `/search/game`에서 `/search/game-sets`로 변경되었습니다.
	- 북마크, 투표, 작성한 게임에 대한 엔드포인트가 `/games/...`에서 `/game-sets/...`로 업데이트되었습니다.

- **버그 수정**
	- 기존의 로직 및 기능은 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->