### PR TITLE
톡픽 임시 저장 시 이미지가 중첩되는 문제 해결

### DIFF
--- a/src/main/java/balancetalk/file/domain/repository/FileRepository.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepository.java
@@ -1,8 +1,10 @@
 package balancetalk.file.domain.repository;
 
 import balancetalk.file.domain.File;
+import balancetalk.file.domain.FileType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FileRepository extends JpaRepository<File, Long>, FileRepositoryCustom {
 
+    void deleteByResourceIdAndFileType(Long tempTalkPickId, FileType fileType);
 }

--- a/src/main/java/balancetalk/talkpick/application/TempTalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TempTalkPickService.java
@@ -34,6 +34,9 @@ public class TempTalkPickService {
 
         if (member.hasTempTalkPick()) {
             Long tempTalkPickId = member.updateTempTalkPick(request.toEntity(member));
+            if (request.isNewRequest()) {
+                fileRepository.deleteByResourceIdAndFileType(tempTalkPickId, TEMP_TALK_PICK);
+            }
             relocateFilesIfContainsFileIds(request, tempTalkPickId);
             return;
         }
@@ -48,6 +51,7 @@ public class TempTalkPickService {
         }
 
         List<Long> deletedFileIds = deleteRequestedFiles(request);
+
 
         if (request.containsNewFileIds()) {
             List<Long> newFileIds = request.getNewFileIds();

--- a/src/main/java/balancetalk/talkpick/dto/TempTalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TempTalkPickDto.java
@@ -23,6 +23,9 @@ public class TempTalkPickDto {
         @Schema(description = "제거할 이미지 파일 ID 목록", example = "[3, 7]")
         private List<Long> deleteFileIds;
 
+        @Schema(description = "최근 임시저장된 톡픽 불러오기 여부", example = "true")
+        private Boolean isLoaded;
+
         public TempTalkPick toEntity(Member member) {
             return TempTalkPick.builder()
                     .title(baseFields.getTitle())
@@ -32,6 +35,10 @@ public class TempTalkPickDto {
                     .sourceUrl(baseFields.getSourceUrl())
                     .member(member)
                     .build();
+        }
+
+        public boolean isNewRequest() {
+            return !isLoaded;
         }
 
         public boolean containsNewFileIds() {


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 임시 저장 API 요청 DTO에 isLoaded 추가 및 그에 따른 로직 구현

## 💡 자세한 설명
임시 저장한 톡픽을 불러오지 않고 새롭게 다시 저장할 때 이미지가 중첩되어 저장되는 문제를 해결하기 위해, 다음과 같이 요청 DTO에 isLoaded 필드를 추가하여 분기처리했습니다.
```java
if (member.hasTempTalkPick()) {
    Long tempTalkPickId = member.updateTempTalkPick(request.toEntity(member));
    if (request.isNewRequest()) {
        fileRepository.deleteByResourceIdAndFileType(tempTalkPickId, TEMP_TALK_PICK);
    }
    relocateFilesIfContainsFileIds(request, tempTalkPickId);
    return;
}
```

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #721 
