### PR TITLE
feat: 일반 유저인 경우 밸런스 게임 메인 태그를 생성하지 못하도록 처리

### DIFF
--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -24,6 +24,7 @@ import balancetalk.global.exception.BalanceTalkException;
 import balancetalk.global.exception.ErrorCode;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
+import balancetalk.member.domain.Role;
 import balancetalk.member.dto.ApiMember;
 import balancetalk.member.dto.GuestOrApiMember;
 import balancetalk.vote.domain.GameVote;
@@ -196,7 +197,11 @@ public class GameService {
 
     @Transactional
     public void createGameMainTag(final CreateGameMainTagRequest request, final ApiMember apiMember) {
-        apiMember.toMember(memberRepository);
+        Member member = apiMember.toMember(memberRepository);
+        if (member.getRole() == Role.USER) {
+            throw new BalanceTalkException(ErrorCode.FORBIDDEN_MAIN_TAG_CREATE);
+        }
+
         boolean hasGameTag = mainTagRepository.existsByName(request.getName());
         if (hasGameTag) {
             throw new BalanceTalkException(ErrorCode.ALREADY_REGISTERED_TAG);

--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -67,6 +67,7 @@ public enum ErrorCode {
     FORBIDDEN_POST_REPORT(FORBIDDEN, "본인 게시글을 신고할 수 없습니다."),
     FORBIDDEN_COMMENT_REPORT(FORBIDDEN, "본인 댓글을 신고할 수 없습니다."),
     FORBIDDEN_LIKE_OWN_COMMENT(FORBIDDEN, "본인 댓글에는 좋아요를 누를 수 없습니다."),
+    FORBIDDEN_MAIN_TAG_CREATE(FORBIDDEN, "메인 태그 작성 권한이 없습니다."),
 
     // 404
     NOT_FOUND_TALK_PICK(NOT_FOUND, "존재하지 않는 톡픽입니다."),


### PR DESCRIPTION
## 💡 작업 내용
- [x] `ADMIN`인 경우에만 메인 태그 생성하도록 수정

## 💡 자세한 설명


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #736 
