### PR TITLE
회원 단일 조회 시 이메일 반환 (프론트 요청) 완료

### DIFF
--- a/src/main/java/balancetalk/member/dto/MemberDto.java
+++ b/src/main/java/balancetalk/member/dto/MemberDto.java
@@ -97,6 +97,9 @@ public class MemberDto {
         @Schema(description = "회원 닉네임", example = "닉네임")
         private String nickname;
 
+        @Schema(description = "회원 이메일", example = "test123@naver.com")
+        private String email;
+
         @Schema(description = "회원 프로필 이미지 URL", example = "https://balancetalk.s3.ap-northeast-2.amazonaws.com/1")
         private String profileImgUrl;
 
@@ -113,6 +116,7 @@ public class MemberDto {
             return MemberResponse.builder()
                     .id(member.getId())
                     .nickname(member.getNickname())
+                    .email(member.getEmail())
                     .profileImgUrl(profileImgUrl)
                     .postsCount(member.getPostsCount())
                     .bookmarkedPostsCount(member.getBookmarkedPostsCount())


### PR DESCRIPTION
## 💡 작업 내용
- [x] `MemberResponse` 에서 이메일 값 반환

## 💡 자세한 설명
<img width="942" alt="스크린샷 2024-11-26 오전 1 18 59" src="https://github.com/user-attachments/assets/4400fcf7-cde1-481b-b5ca-36d04dd54a33">
위 화면에서 회원의 이메일 값을 고정하기 위해 반환하는 필드입니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #740


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 회원 응답에 이메일 주소 필드를 추가하여 회원 정보에 대한 더 나은 접근성을 제공.
	- 이메일 필드가 포함된 회원 응답 생성 기능을 업데이트하여 이메일 정보가 포함되도록 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->