### PR TITLE
비밀번호 검증 API 구현 완료

### DIFF
--- a/src/main/java/balancetalk/member/application/MemberService.java
+++ b/src/main/java/balancetalk/member/application/MemberService.java
@@ -174,4 +174,9 @@ public class MemberService {
             throw new BalanceTalkException(SAME_NICKNAME);
         }
     }
+
+    public boolean validatePassword(String password, ApiMember apiMember) {
+        Member member = apiMember.toMember(memberRepository);
+        return passwordEncoder.matches(password, member.getPassword());
+    }
 }

--- a/src/main/java/balancetalk/member/presentation/MemberController.java
+++ b/src/main/java/balancetalk/member/presentation/MemberController.java
@@ -84,4 +84,11 @@ public class MemberController {
                                  @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         memberService.updateMemberInformation(memberUpdateRequest, apiMember);
     }
+
+    @GetMapping("/validate-password")
+    @Operation(summary = "비밀번호 검증", description = "회원의 비밀번호를 검증한다.")
+    public boolean validatePassword(@RequestParam @NotBlank String password,
+                                 @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        return memberService.validatePassword(password, apiMember);
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [ ] 비밀번호 검증 API 구현

## 💡 자세한 설명
### postman 테스트 완료
해당 API의 경우, 요청 시 보내는 값이 무조건 password 하나이기 때문에, `@RequestParam` 을 사용했습니다.

<img width="619" alt="스크린샷 2024-11-26 오전 1 39 09" src="https://github.com/user-attachments/assets/3a194bb5-09c9-42e5-b403-0506d335dba1">

비밀번호가 일치하면 true, 일치하지 않는다면 false를 반환합니다.
## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #742
