### PR TITLE
imgUrl 생성 방식을 URI 대신 문자열 조합으로 변경

### DIFF
--- a/src/main/java/balancetalk/file/domain/File.java
+++ b/src/main/java/balancetalk/file/domain/File.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import java.net.URI;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -54,10 +53,7 @@ public class File extends BaseTimeEntity {
 
     public void updateDirectoryPathAndImgUrl(String newDirectoryPath, String s3Endpoint) {
         this.directoryPath = newDirectoryPath;
-        this.imgUrl = URI.create(s3Endpoint)
-                .resolve(newDirectoryPath)
-                .resolve(storedName)
-                .toString();
+        this.imgUrl = String.format("%s%s%s", s3Endpoint, newDirectoryPath, storedName);
     }
 
     public void updateResourceId(Long newResourceId) {

--- a/src/main/java/balancetalk/file/domain/FileHandler.java
+++ b/src/main/java/balancetalk/file/domain/FileHandler.java
@@ -2,7 +2,6 @@ package balancetalk.file.domain;
 
 import balancetalk.file.domain.repository.FileRepository;
 import io.awspring.cloud.s3.S3Operations;
-import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -84,10 +83,7 @@ public class FileHandler {
     }
 
     private String getImgUrl(File file, String directoryPath) {
-        return URI.create(s3EndPoint)
-                .resolve(directoryPath)
-                .resolve(file.getStoredName())
-                .toString();
+        return String.format("%s%s%s", s3EndPoint, directoryPath, file.getStoredName());
     }
 
     public void deleteFiles(List<File> files) {

--- a/src/main/java/balancetalk/file/domain/FileHandler.java
+++ b/src/main/java/balancetalk/file/domain/FileHandler.java
@@ -73,10 +73,11 @@ public class FileHandler {
     private File createNewFile(File file, Long resourceId, FileType fileType, String directoryPath) {
         return File.builder()
                 .resourceId(resourceId)
-                .size(file.getSize())
+                .fileType(fileType)
                 .uploadName(file.getUploadName())
                 .storedName(String.format("%s_%s", UUID.randomUUID(), file.getUploadName()))
-                .fileType(fileType)
+                .mimeType(file.getMimeType())
+                .size(file.getSize())
                 .directoryPath(directoryPath)
                 .imgUrl(getImgUrl(file, directoryPath))
                 .build();

--- a/src/main/java/balancetalk/file/domain/FileProcessor.java
+++ b/src/main/java/balancetalk/file/domain/FileProcessor.java
@@ -25,9 +25,9 @@ public class FileProcessor {
                             String mimeType,
                             long size) {
         return File.builder()
-                .uploadName(uploadName)
-                .storedName(storedName)
                 .fileType(fileType)
+                .storedName(storedName)
+                .uploadName(uploadName)
                 .mimeType(mimeType)
                 .size(size)
                 .build();


### PR DESCRIPTION
## 💡 작업 내용
- [x] imgUrl 생성 방식을 URI 대신 문자열 조합으로 변경

## 💡 자세한 설명
이미지 업로드 이름에 공백이 들어가면 인코딩이 안되는 문제가 발생합니다. 
이미지 파일의 uploadName의 공백을 제거한 후 인코딩하는 방식을 생각해봤지만, 코드 복잡도 증가로 인해 다시 문자열 조합으로 변경했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #744 
