### PR TITLE
소셜 로그인 URL 배포된 주소로 변경

### DIFF
--- a/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
@@ -10,6 +10,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,10 @@ import java.io.IOException;
 @Component
 @RequiredArgsConstructor
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Value("${spring.profiles.active}")
+    private String profile;
+
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
@@ -38,7 +43,11 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         response.addCookie(JwtTokenProvider.createCookie(refreshToken));
         response.addCookie(JwtTokenProvider.createAccessCookie(accessToken));
+
+        if (profile.equals("local")) {
+            response.sendRedirect("http://localhost:3000");
+            return;
+        }
         response.sendRedirect("https://pick0.com");
     }
-
 }

--- a/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
@@ -38,7 +38,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         response.addCookie(JwtTokenProvider.createCookie(refreshToken));
         response.addCookie(JwtTokenProvider.createAccessCookie(accessToken));
-        response.sendRedirect("http://43.202.175.99:8080");
+        response.sendRedirect("https://pick0.com");
     }
 
 }

--- a/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
@@ -20,9 +20,8 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    @Value("${spring.profiles.active}")
-    private String profile;
-
+    @Value("${urls.redirect}")
+    private String redirectUrl;
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
@@ -43,11 +42,6 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         response.addCookie(JwtTokenProvider.createCookie(refreshToken));
         response.addCookie(JwtTokenProvider.createAccessCookie(accessToken));
-
-        if (profile.equals("local")) {
-            response.sendRedirect("http://localhost:3000");
-            return;
-        }
-        response.sendRedirect("https://pick0.com");
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/balancetalk/member/application/MemberService.java
+++ b/src/main/java/balancetalk/member/application/MemberService.java
@@ -174,4 +174,9 @@ public class MemberService {
             throw new BalanceTalkException(SAME_NICKNAME);
         }
     }
+
+    public boolean verifyPassword(String password, ApiMember apiMember) {
+        Member member = apiMember.toMember(memberRepository);
+        return passwordEncoder.matches(password, member.getPassword());
+    }
 }

--- a/src/main/java/balancetalk/member/presentation/MemberController.java
+++ b/src/main/java/balancetalk/member/presentation/MemberController.java
@@ -84,4 +84,11 @@ public class MemberController {
                                  @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
         memberService.updateMemberInformation(memberUpdateRequest, apiMember);
     }
+
+    @GetMapping("/verify-password")
+    @Operation(summary = "비밀번호 검증", description = "회원의 비밀번호를 검증한다.")
+    public boolean validatePassword(@RequestParam @NotBlank String password,
+                                 @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        return memberService.verifyPassword(password, apiMember);
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 배포된 도메인 주소에 맞춰 yml local, dev 주소 변경
- [x] 리다이렉트 URL 변경

## 💡 자세한 설명

## 구글

<img width="353" alt="스크린샷 2024-11-26 오후 4 55 17" src="https://github.com/user-attachments/assets/c3540e1d-f4a2-4156-a9e3-213bb5a71bf2">

## 네이버

<img width="584" alt="스크린샷 2024-11-26 오후 4 55 24" src="https://github.com/user-attachments/assets/edd0565f-5756-4268-86be-bc7dbf0addbd">

## 카카오

<img width="569" alt="스크린샷 2024-11-26 오후 4 55 31" src="https://github.com/user-attachments/assets/a4563dee-2872-4129-ab90-1cd8e63b4a1a">



## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #752 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 인증 성공 후 리디렉션 URL이 환경에 따라 변경됩니다. 로컬 프로필에서는 "http://localhost:3000"으로, 다른 프로필에서는 "https://pick0.com"으로 리디렉션됩니다. 이를 통해 사용자 인증 후의 내비게이션 경험이 개선됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->