### PR TITLE
게임 수정 API 호출 시 이미지 중첩되는 문제 해결

### DIFF
--- a/src/main/java/balancetalk/game/domain/GameOption.java
+++ b/src/main/java/balancetalk/game/domain/GameOption.java
@@ -84,4 +84,8 @@ public class GameOption {
     public void decreaseVotesCount() {
         this.votesCount--;
     }
+
+    public boolean hasImage() {
+        return imgUrl != null && imgId != null;
+    }
 }

--- a/src/main/java/balancetalk/game/domain/GameOption.java
+++ b/src/main/java/balancetalk/game/domain/GameOption.java
@@ -41,6 +41,8 @@ public class GameOption {
     @Size(max = 30)
     private String name;
 
+    private Long imgId;
+
     private String imgUrl;
 
     @Size(max = 50)
@@ -65,6 +67,7 @@ public class GameOption {
     }
 
     public void updateGameOption(GameOption newGameOption) {
+        this.imgId = newGameOption.getImgId();
         this.imgUrl = newGameOption.getImgUrl();
         this.name = newGameOption.getName();
         this.description = newGameOption.getDescription();

--- a/src/main/java/balancetalk/game/dto/GameOptionDto.java
+++ b/src/main/java/balancetalk/game/dto/GameOptionDto.java
@@ -56,6 +56,7 @@ public class GameOptionDto {
         }
         return GameOption.builder()
                 .name(name)
+                .imgId(fileId)
                 .imgUrl(newImgUrl)
                 .description(description)
                 .optionType(optionType)


### PR DESCRIPTION
## 💡 작업 내용
- [x] GameOption에 imgId 추가
- [x] 게임 수정 API 호출 시 이미지 중첩되는 문제 해결

## 💡 자세한 설명
게임 수정 API 호출 시 이미지 중첩되는 문제를 해결했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #763 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 게임 옵션에 이미지 식별자를 추가하여 이미지 처리 기능을 향상시켰습니다.
	- 게임 세트 생성 및 업데이트 로직을 개선하여 파일 처리 방식을 최적화했습니다.

- **버그 수정**
	- 이미지가 있는 게임 옵션의 파일을 적절히 처리하도록 로직을 수정했습니다.

- **문서화**
	- `GameOptionDto` 클래스의 `toEntity` 메서드에 새로운 필드 `imgId`를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->