### PR TITLE
프로필 이미지를 프렌즈 이미지로 등록 시 해당 파일이 업데이트되지 않도록 수정

### DIFF
--- a/src/main/java/balancetalk/file/domain/File.java
+++ b/src/main/java/balancetalk/file/domain/File.java
@@ -1,5 +1,7 @@
 package balancetalk.file.domain;
 
+import static balancetalk.file.domain.FileType.FRIENDS;
+
 import balancetalk.global.common.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -70,5 +72,9 @@ public class File extends BaseTimeEntity {
 
     public boolean isUnmapped() {
         return directoryPath.endsWith("temp/") && resourceId == null;
+    }
+
+    public boolean isUploadedByMember() {
+        return fileType != FRIENDS;
     }
 }

--- a/src/main/java/balancetalk/member/application/MemberService.java
+++ b/src/main/java/balancetalk/member/application/MemberService.java
@@ -68,7 +68,9 @@ public class MemberService {
         if (joinRequest.hasProfileImgId()) {
             File newProfileImgFile = fileRepository.findById(joinRequest.getProfileImgId())
                     .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_FILE));
-            fileHandler.relocateFile(newProfileImgFile, savedMember.getId(), FileType.MEMBER);
+            if (newProfileImgFile.isUploadedByMember()) {
+                fileHandler.relocateFile(newProfileImgFile, savedMember.getId(), FileType.MEMBER);
+            }
         }
     }
 
@@ -168,14 +170,18 @@ public class MemberService {
 
         if (memberUpdateRequest.getProfileImgId() != null) {
             if (member.hasProfileImgId()) {
-                File file = fileRepository.findById(member.getProfileImgId())
+                File oldProfileImgFile = fileRepository.findById(member.getProfileImgId())
                         .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_FILE));
-                fileHandler.deleteFile(file);
+                if (oldProfileImgFile.isUploadedByMember()) {
+                    fileHandler.deleteFile(oldProfileImgFile);
+                }
             }
-            member.updateImageId(memberUpdateRequest.getProfileImgId());
-            File file = fileRepository.findById(member.getProfileImgId())
+            File newProfileImgFile = fileRepository.findById(memberUpdateRequest.getProfileImgId())
                     .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_FILE));
-            fileHandler.relocateFile(file, member.getId(), FileType.MEMBER);
+            member.updateImageId(newProfileImgFile.getId());
+            if (newProfileImgFile.isUploadedByMember()) {
+                fileHandler.relocateFile(newProfileImgFile, member.getId(), FileType.MEMBER);
+            }
         }
 
         if (memberUpdateRequest.getNickname() != null) {


### PR DESCRIPTION
## 💡 작업 내용
- [x] 프로필 이미지를 프렌즈 이미지로 등록 시 해당 파일이 업데이트되지 않도록 수정

## 💡 자세한 설명
프로필 이미지로 등록하려는 파일이 일반 유저가 업로드한 파일인지 확인하는 메서드를 통해 #765 이슈를 해결했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #765 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 파일 업로드 시, 사용자가 업로드한 파일인지 확인하는 기능 추가.
	- 회원 등록 및 정보 업데이트 시 프로필 이미지 처리 로직 개선.

- **버그 수정**
	- 회원이 업로드한 프로필 이미지만 삭제하도록 조건 추가. 

이러한 변경 사항은 파일 관리의 무결성을 강화하고, 회원의 데이터 손실을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->