### PR TITLE
CommentService Duplicates 제거, 비밀번호 검증 API 보안성 향상

### DIFF
--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -219,20 +219,26 @@ public class CommentService {
         comment.setIsBest(likeCount >= MIN_COUNT_FOR_BEST_COMMENT || likeCount == maxLikes);
 
         // BestCommentResponse 생성
-        return convertBestCommentResponse(member, comment, option, likeCount, myLike);
+        return createBestCommentResponse(member, comment, option, likeCount, myLike);
     }
 
 
-    private BestCommentResponse convertBestCommentResponse(Member member, Comment comment, VoteOption option,
-                                                           int likeCount, boolean myLike) {
-        if (member.getProfileImgId() != null) {
-            String imgUrl = fileRepository.findById(member.getProfileImgId())
-                    .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_FILE))
-                    .getImgUrl();
+    private BestCommentResponse createBestCommentResponse(Member member, Comment comment, VoteOption option, int likeCount, boolean myLike) {
+        // 프로필 이미지 URL 조회
+        String imgUrl = fetchProfileImgUrl(member);
 
-            return BestCommentResponse.fromEntity(comment, option, imgUrl, likeCount, myLike);
+        // BestCommentResponse 생성
+        return BestCommentResponse.fromEntity(comment, option, imgUrl, likeCount, myLike);
+    }
+
+    // 프로필 이미지 URL 조회
+    private String fetchProfileImgUrl(Member member) {
+        if (member.getProfileImgId() == null) {
+            return null;
         }
-            return BestCommentResponse.fromEntity(comment, option, null, likeCount, myLike);
+        return fileRepository.findById(member.getProfileImgId())
+                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_FILE))
+                .getImgUrl();
     }
 
     public void updateComment(Long commentId, Long talkPickId, String content, ApiMember apiMember) {

--- a/src/main/java/balancetalk/member/application/MemberService.java
+++ b/src/main/java/balancetalk/member/application/MemberService.java
@@ -190,8 +190,11 @@ public class MemberService {
         }
     }
 
-    public boolean verifyPassword(String password, ApiMember apiMember) {
+    public void verifyPassword(String password, ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
-        return passwordEncoder.matches(password, member.getPassword());
+
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw new BalanceTalkException(PASSWORD_MISMATCH);
+        }
     }
 }

--- a/src/main/java/balancetalk/member/presentation/MemberController.java
+++ b/src/main/java/balancetalk/member/presentation/MemberController.java
@@ -85,10 +85,10 @@ public class MemberController {
         memberService.updateMemberInformation(memberUpdateRequest, apiMember);
     }
 
-    @GetMapping("/verify-password")
+    @PostMapping("/verify-password")
     @Operation(summary = "비밀번호 검증", description = "회원의 비밀번호를 검증한다.")
-    public boolean validatePassword(@RequestParam @NotBlank String password,
+    public void validatePassword(@RequestParam @NotBlank String password,
                                  @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
-        return memberService.verifyPassword(password, apiMember);
+        memberService.verifyPassword(password, apiMember);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [ ] `CommentService` Duplicates 제거
- [ ] 비밀번호 검증 API 보안성 향상

## 💡 자세한 설명
### 비밀번호 검증 API

```java
@PostMapping("/verify-password")
    @Operation(summary = "비밀번호 검증", description = "회원의 비밀번호를 검증한다.")
    public void validatePassword(@RequestParam @NotBlank String password,
                                 @Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
        memberService.verifyPassword(password, apiMember);
    }
```
GET 대신 POST 메서드를 사용해 비밀번호가 URL에 노출될 가능성을 없앴고, 브루트포스 공격에 대비하여 boolean 값 반환 대신 비밀번호가 틀릴 시 에러코드를 띄우는 것으로 설정했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #768