### PR TITLE
임시저장 업데이트 시 메인, 서브태그 값 업데이트

### DIFF
--- a/src/main/java/balancetalk/game/application/TempGameService.java
+++ b/src/main/java/balancetalk/game/application/TempGameService.java
@@ -50,7 +50,7 @@ public class TempGameService {
 
         if (member.hasTempGameSet()) { // 기존 임시저장이 존재하는 경우
             TempGameSet existGame = member.getTempGameSet();
-            existGame.updateTempGameSet(request.getTitle(), newTempGames);
+            existGame.updateTempGameSet(request.getTitle(), request.getSubTag(), mainTag, newTempGames);
             processTempGameFiles(tempGames, existGame.getTempGames());
             return;
         }

--- a/src/main/java/balancetalk/game/domain/TempGameSet.java
+++ b/src/main/java/balancetalk/game/domain/TempGameSet.java
@@ -62,8 +62,10 @@ public class TempGameSet extends BaseTimeEntity {
         });
     }
 
-    public void updateTempGameSet(String title, List<TempGame> newTempGames) {
+    public void updateTempGameSet(String title, String subTag, MainTag mainTag, List<TempGame> newTempGames) {
         this.title = title;
+        this.subTag = subTag;
+        this.mainTag = mainTag;
         IntStream.range(0, this.tempGames.size()).forEach(i -> {
             TempGame existingGame = this.tempGames.get(i);
             TempGame newGame = newTempGames.get(i);


### PR DESCRIPTION
## 💡 작업 내용
- [x] 업데이트 시 메인태그와 서브태그 값도 함께 변경합니다.

## 💡 자세한 설명

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #772 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 개선**
	- 기존 임시 게임 세트를 업데이트할 때 서브 태그와 메인 태그를 포함하도록 개선되었습니다.
	- 임시 게임 세트의 여러 속성을 한 번의 호출로 업데이트할 수 있는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->