### PR TITLE
게임 수정 시 파일 처리 로직에서 발생하는 문제 해결

### DIFF
--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -91,38 +91,58 @@ public class GameService {
         List<Game> newGames = request.getGames().stream()
                 .map(gameRequest -> gameRequest.toEntity(fileRepository))
                 .toList();
-
         List<Game> oldGames = gameSet.getGames();
+
+        updateGameFiles(newGames, oldGames);
+
+        gameSet.updateGameSetRequest(request.getTitle(), mainTag, request.getSubTag(), newGames);
+    }
+
+    private void updateGameFiles(List<Game> newGames, List<Game> oldGames) {
         for (int i = 0; i < 10; i++) {
             Game oldGame = oldGames.get(i);
             Game newGame = newGames.get(i);
-            List<GameOption> oldGameGameOptions = oldGame.getGameOptions();
-            List<GameOption> newGameGameOptions = newGame.getGameOptions();
-            for (int j = 0; j < 2; j++) {
-                GameOption oldGameOption = oldGameGameOptions.get(j);
-                GameOption newGameOption = newGameGameOptions.get(j);
-                if (oldGameOption.hasImage()) {
-                    if (newGameOption.hasImage()) {
-                        if (newGameOption.getImgId().equals(oldGameOption.getImgId())) {
-                            // 기존 파일 유지
-                            continue;
-                        }
-                    }
-                    // 기존 파일 제거
-                    File oldFile = fileRepository.findById(oldGameOption.getImgId())
-                            .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
-                    fileHandler.deleteFile(oldFile);
-                }
-                if (newGameOption.hasImage()) {
-                    // 새로운 파일 매핑
-                    File newFile = fileRepository.findById(newGameOption.getImgId())
-                            .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
-                    fileHandler.relocateFile(newFile, oldGameOption.getId(), GAME_OPTION);
-                }
-            }
+            processGameFiles(oldGame, newGame);
         }
+    }
 
-        gameSet.updateGameSetRequest(request.getTitle(), mainTag, request.getSubTag(), newGames);
+    private void processGameFiles(Game oldGame, Game newGame) {
+        for (int j = 0; j < 2; j++) {
+            List<GameOption> oldGameOptions = oldGame.getGameOptions();
+            List<GameOption> newGameOptions = newGame.getGameOptions();
+            processGameOptionFiles(oldGameOptions.get(j), newGameOptions.get(j));
+        }
+    }
+
+    private void processGameOptionFiles(GameOption oldGameOption, GameOption newGameOption) {
+        if (oldGameOption.hasImage()) {
+            if (isEqualsImgId(oldGameOption, newGameOption)) {
+                // 기존 파일 유지
+                return;
+            }
+            // 기존 파일 제거
+            deleteOldFile(oldGameOption);
+        }
+        if (newGameOption.hasImage()) {
+            // 새로운 파일 매핑
+            relocateNewFile(oldGameOption, newGameOption);
+        }
+    }
+
+    private boolean isEqualsImgId(GameOption oldGameOption, GameOption newGameOption) {
+        return newGameOption.hasImage() && newGameOption.getImgId().equals(oldGameOption.getImgId());
+    }
+
+    private void deleteOldFile(GameOption oldGameOption) {
+        File oldFile = fileRepository.findById(oldGameOption.getImgId())
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
+        fileHandler.deleteFile(oldFile);
+    }
+
+    private void relocateNewFile(GameOption oldGameOption, GameOption newGameOption) {
+        File newFile = fileRepository.findById(newGameOption.getImgId())
+                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
+        fileHandler.relocateFile(newFile, oldGameOption.getId(), GAME_OPTION);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -114,7 +114,7 @@ public class GameService {
                     fileHandler.deleteFile(oldFile);
                 }
                 if (newGameOption.hasImage()) {
-                    // 새로운 파일로 변경
+                    // 새로운 파일 매핑
                     File newFile = fileRepository.findById(newGameOption.getImgId())
                             .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
                     fileHandler.relocateFile(newFile, oldGameOption.getId(), GAME_OPTION);

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -33,12 +33,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameService {
@@ -103,8 +101,6 @@ public class GameService {
             for (int j = 0; j < 2; j++) {
                 GameOption oldGameOption = oldGameGameOptions.get(j);
                 GameOption newGameOption = newGameGameOptions.get(j);
-                log.info("optionId = {}", oldGameOption.getId());
-
                 if (oldGameOption.hasImage()) {
                     if (newGameOption.hasImage()) {
                         if (newGameOption.getImgId().equals(oldGameOption.getImgId())) {

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -103,12 +103,22 @@ public class GameService {
             for (int j = 0; j < 2; j++) {
                 GameOption oldGameOption = oldGameGameOptions.get(j);
                 GameOption newGameOption = newGameGameOptions.get(j);
-                if (newGameOption.hasImage()) {
-                    if (oldGameOption.hasImage()) {
-                        File oldFile = fileRepository.findById(oldGameOption.getImgId())
-                                .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
-                        fileHandler.deleteFile(oldFile);
+                log.info("optionId = {}", oldGameOption.getId());
+
+                if (oldGameOption.hasImage()) {
+                    if (newGameOption.hasImage()) {
+                        if (newGameOption.getImgId().equals(oldGameOption.getImgId())) {
+                            // 기존 파일 유지
+                            continue;
+                        }
                     }
+                    // 기존 파일 제거
+                    File oldFile = fileRepository.findById(oldGameOption.getImgId())
+                            .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
+                    fileHandler.deleteFile(oldFile);
+                }
+                if (newGameOption.hasImage()) {
+                    // 새로운 파일로 변경
                     File newFile = fileRepository.findById(newGameOption.getImgId())
                             .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_FILE));
                     fileHandler.relocateFile(newFile, oldGameOption.getId(), GAME_OPTION);


### PR DESCRIPTION
## 💡 작업 내용
- [x] 게임 수정 시 파일 처리 로직에서 발생하는 문제 해결
- [x] `@Slf4J` 제거 

## 💡 자세한 설명
### 게임 수정 시 발생 가능한 경우의 수
1. 기존에 매핑된 파일이 없는 상태에서 새로운 파일을 업로드하지 않는 경우
2. 기존에 매핑된 파일이 없는 상태에서 새로운 파일을 업로드하는 경우
3. 기존에 매핑된 파일이 있는 상태에서 (해당 파일 제거 후) 새로운 파일을 업로드하지 않는 경우
4. 기존에 매핑된 파일이 있는 상태에서 (해당 파일 제거 후) 새로운 파일을 업로드하는 경우
5. 기존에 매핑된 파일 그대로 유지하는 경우

### 게임 수정 시 발생 가능한 경우의 수를 시각적으로 표현한 흐름도
<img width="626" alt="스크린샷 2024-11-30 오전 3 58 25" src="https://github.com/user-attachments/assets/22bd7cc1-cce1-4394-bb26-ced470bf8a55">


## 📢 리뷰 요구 사항
제가 놓친 경우가 있다면 알려주세요!

## 🚩 후속 작업
추후 여유가 생기면 코드 구조 개선을 진행할 예정입니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #776 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **기능 개선**
	- 게임 옵션에 관련된 이미지 파일 처리 로직 개선: 새로운 게임 옵션의 이미지 ID가 이전 것과 일치할 경우, 이전 파일을 삭제하지 않도록 변경되었습니다.
- **버그 수정**
	- 파일 작업과 관련된 오류 처리 개선: 불필요한 파일 삭제를 방지하여 자원 관리가 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->