### PR TITLE
톡픽 DTO 내 공통 필드 클래스에 @Valid 추가 및 네이밍 개선

### DIFF
--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -8,12 +8,15 @@ import balancetalk.bookmark.domain.TalkPickBookmark;
 import balancetalk.comment.domain.Comment;
 import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.TalkPick;
+import balancetalk.talkpick.dto.fiedls.BaseTalkPickFields;
+import balancetalk.talkpick.dto.fiedls.ValidatedNotBlankTalkPickFields;
 import balancetalk.vote.domain.TalkPickVote;
 import balancetalk.vote.domain.VoteOption;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -29,7 +32,8 @@ public class TalkPickDto {
     @AllArgsConstructor
     public static class CreateTalkPickRequest {
 
-        private BaseTalkPickFields baseFields;
+        @Valid
+        private ValidatedNotBlankTalkPickFields baseFields;
 
         @Schema(description = "첨부한 이미지 파일 ID 목록", example = "[12, 41]")
         @Size(max = 10, message = "톡픽 생성 시 업로드할 수 있는 파일 개수는 최대 10개입니다.")
@@ -60,7 +64,8 @@ public class TalkPickDto {
     @AllArgsConstructor
     public static class UpdateTalkPickRequest {
 
-        private BaseTalkPickFields baseFields;
+        @Valid
+        private ValidatedNotBlankTalkPickFields baseFields;
 
         @Schema(description = "새로 첨부한 이미지 파일 ID 목록", example = "[12, 41]")
         @Size(max = 10, message = "톡픽 생성 시 업로드할 수 있는 파일 개수는 최대 10개입니다.")

--- a/src/main/java/balancetalk/talkpick/dto/TempTalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TempTalkPickDto.java
@@ -2,8 +2,10 @@ package balancetalk.talkpick.dto;
 
 import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.TempTalkPick;
+import balancetalk.talkpick.dto.fiedls.BaseTalkPickFields;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -18,7 +20,8 @@ public class TempTalkPickDto {
     @AllArgsConstructor
     public static class SaveTempTalkPickRequest {
 
-        private BaseTempTalkPickFields baseFields;
+        @Valid
+        private BaseTalkPickFields baseFields;
 
         @Schema(description = "새로 첨부한 이미지 파일 ID 목록", example = "[12, 41]")
         @Size(max = 10, message = "톡픽 생성 시 업로드할 수 있는 파일 개수는 최대 10개입니다.")

--- a/src/main/java/balancetalk/talkpick/dto/fiedls/BaseTalkPickFields.java
+++ b/src/main/java/balancetalk/talkpick/dto/fiedls/BaseTalkPickFields.java
@@ -1,4 +1,4 @@
-package balancetalk.talkpick.dto;
+package balancetalk.talkpick.dto.fiedls;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
@@ -16,6 +16,7 @@ public class BaseTalkPickFields {
     private String title;
 
     @Schema(description = "본문 내용", example = "본문 내용")
+    @Size(max = 2000, message = "본문은 2,000자 이하여야 합니다.")
     private String content;
 
     @Schema(description = "선택지 A 이름", example = "선택지 A 이름")

--- a/src/main/java/balancetalk/talkpick/dto/fiedls/ValidatedNotBlankTalkPickFields.java
+++ b/src/main/java/balancetalk/talkpick/dto/fiedls/ValidatedNotBlankTalkPickFields.java
@@ -1,10 +1,10 @@
-package balancetalk.talkpick.dto;
+package balancetalk.talkpick.dto.fiedls;
 
 import jakarta.validation.constraints.NotBlank;
 
-public class BaseTempTalkPickFields extends BaseTalkPickFields {
+public class ValidatedNotBlankTalkPickFields extends BaseTalkPickFields {
 
-    public BaseTempTalkPickFields(String title, String content, String optionA, String optionB, String sourceUrl) {
+    public ValidatedNotBlankTalkPickFields(String title, String content, String optionA, String optionB, String sourceUrl) {
         super(title, content, optionA, optionB, sourceUrl);
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 DTO 내 공통 필드 클래스에 @Valid 추가 
- [x] 공통 필드 클래스 네이밍 개선

## 💡 자세한 설명
톡픽 생성, 수정, 임시 저장 시 필드를 정상적으로 검증하도록 하기 위해 내부 필드에 `@Valid`를 추가했습니다. 
그리고 공통 필드를 가진 클래스의 의미를 명확히 하기 위해 네이밍을 개선했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #731 
