### PR TITLE
로그인 후 500에러 발생 

### DIFF
--- a/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/balancetalk/global/jwt/JwtTokenProvider.java
@@ -29,7 +29,7 @@ public class JwtTokenProvider {
     @Value("${spring.jwt.token.refresh-expiration-time}")
     private long refreshExpirationTime;
 
-    private static final String MEMBER_ID = "MEMBER_ID";
+    private static final String MEMBER_ID = "memberId";
     private final MyUserDetailService myUserDetailService;
     private final Key secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS512);
 
@@ -152,6 +152,6 @@ public class JwtTokenProvider {
 
     public Long getMemberId(String token) {
         Claims claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
-        return claims.get("memberId", Long.class);
+        return claims.get(MEMBER_ID, Long.class);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 로그인 후 인가 필요한 API에서 발생하는 500에러 해결

## 💡 자세한 설명
토큰 claims에 넣을 때 `member_id`로 넣어줬는데 조회할 때는 `memberId`로 조회해서 문제가 발생했습니다.

`memberId`로 통일했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #787 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- JWT 토큰에서 멤버 ID 상수 이름을 `"MEMBER_ID"`에서 `"memberId"`로 변경하여 일관성을 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->