### PR TITLE
READ_ONLY accesMode를 통해 요청을 보낼 때 필드값이 보이지 않도록 수정

### DIFF
--- a/src/main/java/balancetalk/game/dto/GameOptionDto.java
+++ b/src/main/java/balancetalk/game/dto/GameOptionDto.java
@@ -19,13 +19,15 @@ public class GameOptionDto {
     @Schema(description = "선택지 이름", example = "선택지 이름")
     private String name;
 
-    @Schema(description = "선택지 이미지",
-            example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/4839036ee7cd_unnamed.png")
-    private String imgUrl;
-
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Schema(description = "선택지 이미지 파일 ID", example = "12")
     private Long fileId;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "선택지 이미지",
+            example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/4839036ee7cd_unnamed.png",
+            accessMode = Schema.AccessMode.READ_ONLY)
+    private String imgUrl;
 
     @Schema(description = "선택지 추가설명", example = "선택지 추가 설명")
     private String description;

--- a/src/main/java/balancetalk/game/dto/TempGameOptionDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameOptionDto.java
@@ -24,7 +24,8 @@ public class TempGameOptionDto {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Schema(description = "선택지 이미지",
-            example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/4839036ee7cd_unnamed.png")
+            example = "https://pikko-image.s3.ap-northeast-2.amazonaws.com/balance-game/4839036ee7cd_unnamed.png",
+            accessMode = Schema.AccessMode.READ_ONLY)
     private String imgUrl;
 
     @Schema(description = "선택지 추가설명", example = "선택지 추가 설명")


### PR DESCRIPTION
## 💡 작업 내용
- [x] 스웨거 문서 상에서 불필요한 필드 제거

## 💡 자세한 설명
`READ_ONLY`로 설정된 필드는 요청 시에는 해당 필드가 제외되고, 응답 시에만 JSON에 포함된다고 합니다. 따라서, 응답 시에만 imgUrl이 포함되도록 수정했습니다.

![스크린샷 2024-12-08 오후 5 59 10](https://github.com/user-attachments/assets/4c1b80f4-870d-4c89-b82e-535d2e724297)

![스크린샷 2024-12-08 오후 5 59 10](https://github.com/user-attachments/assets/48da1703-e2c2-4519-a17b-a8ca69e55cf6)



## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #795 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- `GameOptionDto` 및 `TempGameOptionDto` 클래스의 `imgUrl` 필드에 대해 읽기 전용 접근 모드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->