### PR TITLE
소셜로그인, 일반로그인 여부 구분 및 리다이렉트 추가 

### DIFF
--- a/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/balancetalk/global/oauth2/CustomSuccessHandler.java
@@ -10,7 +10,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -19,9 +18,6 @@ import java.io.IOException;
 @Component
 @RequiredArgsConstructor
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-
-    @Value("${urls.redirect}")
-    private String redirectUrl;
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
@@ -42,6 +38,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         response.addCookie(JwtTokenProvider.createCookie(refreshToken));
         response.addCookie(JwtTokenProvider.createAccessCookie(accessToken));
+
+        String redirectUrl = customUserDetails.getRedirectUrl();
         response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/balancetalk/global/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/balancetalk/global/oauth2/dto/CustomOAuth2User.java
@@ -11,10 +11,15 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 public class CustomOAuth2User implements OAuth2User {
 
     private final Oauth2Dto oauth2Dto;
+    private final String redirectUrl;
 
     @Override
     public Map<String, Object> getAttributes() {
         return Map.of();
+    }
+
+    public String getRedirectUrl() {
+        return redirectUrl;
     }
 
     @Override

--- a/src/main/java/balancetalk/global/oauth2/dto/Oauth2Dto.java
+++ b/src/main/java/balancetalk/global/oauth2/dto/Oauth2Dto.java
@@ -1,7 +1,11 @@
 package balancetalk.global.oauth2.dto;
 
+import static balancetalk.member.domain.Role.*;
+import static balancetalk.member.domain.SignupType.*;
+
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.Role;
+import balancetalk.member.domain.SignupType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,13 +18,15 @@ public class Oauth2Dto {
     private String name;
     private String email;
     private Role role;
+    private SignupType signupType;
     private String password;
 
     public Member toEntity() {
         return Member.builder()
                 .nickname(name)
                 .email(email)
-                .role(Role.USER)
+                .role(USER)
+                .signupType(SOCIAL)
                 .password(password)
                 .build();
     }

--- a/src/main/java/balancetalk/global/oauth2/dto/Oauth2Dto.java
+++ b/src/main/java/balancetalk/global/oauth2/dto/Oauth2Dto.java
@@ -1,7 +1,9 @@
 package balancetalk.global.oauth2.dto;
 
-import static balancetalk.member.domain.Role.*;
-import static balancetalk.member.domain.SignupType.*;
+
+
+import static balancetalk.member.domain.Role.USER;
+import static balancetalk.member.domain.SignupType.SOCIAL;
 
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.Role;

--- a/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
@@ -1,8 +1,8 @@
 package balancetalk.global.oauth2.service;
 
-import static balancetalk.global.config.SecurityConfig.*;
-import static balancetalk.member.domain.Role.*;
-import static balancetalk.member.domain.SignupType.*;
+import static balancetalk.global.config.SecurityConfig.passwordEncoder;
+import static balancetalk.member.domain.Role.USER;
+import static balancetalk.member.domain.SignupType.STANDARD;
 
 import balancetalk.global.oauth2.dto.CustomOAuth2User;
 import balancetalk.global.oauth2.dto.GoogleResponse;

--- a/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
@@ -1,6 +1,9 @@
 package balancetalk.global.oauth2.service;
 
 import static balancetalk.global.config.SecurityConfig.*;
+import static balancetalk.member.domain.Role.*;
+import static balancetalk.member.domain.SignupType.*;
+
 import balancetalk.global.oauth2.dto.CustomOAuth2User;
 import balancetalk.global.oauth2.dto.GoogleResponse;
 import balancetalk.global.oauth2.dto.KakaoResponse;
@@ -9,10 +12,8 @@ import balancetalk.global.oauth2.dto.Oauth2Dto;
 import balancetalk.global.oauth2.dto.Oauth2Response;
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.MemberRepository;
-import balancetalk.member.domain.Role;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -20,13 +21,18 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     @Value("${spring.security.security.oauth2-password}")
     private String oauth2Password;
+
+    @Value("${urls.firstLoggedIn}")
+    private String firstLoggedInUrl;
+
+    @Value("${urls.alreadyLoggedIn}")
+    private String alreadyLoggedInUrl;
 
     private final MemberRepository memberRepository;
 
@@ -44,21 +50,21 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         };
 
         String email = getEmail(oauth2Response);
-        String provider = getProvider(oauth2Response);
-        Member findMember = memberRepository.findByEmail(provider + "_" + email).orElse(null);
+        Member findMember = memberRepository.findByEmail(email).orElse(null);
 
         if (findMember == null) {
             String encodedPassword = passwordEncoder().encode(oauth2Password);
             Oauth2Dto oauth2Dto = Oauth2Dto.builder()
                     .name(hideNickname(email))
-                    .email(provider + "_" + email)
-                    .role(Role.USER)
+                    .email(email)
+                    .role(USER)
+                    .signupType(STANDARD)
                     .password(encodedPassword)
                     .build();
 
             Member newMember = oauth2Dto.toEntity();
             memberRepository.save(newMember);
-            return new CustomOAuth2User(oauth2Dto);
+            return new CustomOAuth2User(oauth2Dto, firstLoggedInUrl);
         }
 
         else { // 회원이 존재할 떄
@@ -67,7 +73,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .email(findMember.getEmail())
                     .role(findMember.getRole())
                     .build();
-            return new CustomOAuth2User(oauth2Dto);
+            return new CustomOAuth2User(oauth2Dto, alreadyLoggedInUrl);
         }
     }
 
@@ -85,12 +91,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private String getEmail(Oauth2Response oauth2Response) {
         return Optional.ofNullable(oauth2Response)
                 .map(Oauth2Response::getEmail)
-                .orElse("null");
-    }
-
-    private String getProvider(Oauth2Response oauth2Response) {
-        return Optional.ofNullable(oauth2Response)
-                .map(Oauth2Response::getProvider)
                 .orElse("null");
     }
 }

--- a/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
@@ -28,11 +28,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @Value("${spring.security.security.oauth2-password}")
     private String oauth2Password;
 
-    @Value("${urls.firstLoggedIn}")
-    private String firstLoggedInUrl;
+    @Value("${urls.firstRegister}")
+    private String firstRegisterUrl;
 
-    @Value("${urls.alreadyLoggedIn}")
-    private String alreadyLoggedInUrl;
+    @Value("${urls.alreadyRegistered}")
+    private String alreadyRegisteredUrl;
 
     private final MemberRepository memberRepository;
 
@@ -64,7 +64,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             Member newMember = oauth2Dto.toEntity();
             memberRepository.save(newMember);
-            return new CustomOAuth2User(oauth2Dto, firstLoggedInUrl);
+            return new CustomOAuth2User(oauth2Dto, firstRegisterUrl);
         }
 
         else { // 회원이 존재할 떄
@@ -73,7 +73,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .email(findMember.getEmail())
                     .role(findMember.getRole())
                     .build();
-            return new CustomOAuth2User(oauth2Dto, alreadyLoggedInUrl);
+            return new CustomOAuth2User(oauth2Dto, alreadyRegisteredUrl);
         }
     }
 

--- a/src/main/java/balancetalk/member/domain/Member.java
+++ b/src/main/java/balancetalk/member/domain/Member.java
@@ -63,6 +63,9 @@ public class Member extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private Role role;
 
+    @Enumerated(value = EnumType.STRING)
+    private SignupType signupType;
+
     private Long profileImgId;
 
     @OneToMany(mappedBy = "member")

--- a/src/main/java/balancetalk/member/domain/SignupType.java
+++ b/src/main/java/balancetalk/member/domain/SignupType.java
@@ -1,0 +1,5 @@
+package balancetalk.member.domain;
+
+public enum SignupType {
+    SOCIAL, STANDARD
+}

--- a/src/main/java/balancetalk/member/dto/MemberDto.java
+++ b/src/main/java/balancetalk/member/dto/MemberDto.java
@@ -1,6 +1,7 @@
 package balancetalk.member.dto;
 
-import static balancetalk.member.domain.SignupType.*;
+
+import static balancetalk.member.domain.SignupType.STANDARD;
 
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.Role;

--- a/src/main/java/balancetalk/member/dto/MemberDto.java
+++ b/src/main/java/balancetalk/member/dto/MemberDto.java
@@ -124,6 +124,9 @@ public class MemberDto {
         @Schema(description = "저장한 게시글 수", example = "21")
         private int bookmarkedPostsCount;
 
+        @Schema(description = "회원 가입 경로", example = "STANDARD")
+        private SignupType signupType;
+
         public static MemberResponse fromEntity(Member member, String profileImgUrl) {
             return MemberResponse.builder()
                     .id(member.getId())
@@ -133,6 +136,7 @@ public class MemberDto {
                     .createdAt(member.getCreatedAt())
                     .postsCount(member.getPostsCount())
                     .bookmarkedPostsCount(member.getBookmarkedPostsCount())
+                    .signupType(member.getSignupType())
                     .build();
         }
     }

--- a/src/main/java/balancetalk/member/dto/MemberDto.java
+++ b/src/main/java/balancetalk/member/dto/MemberDto.java
@@ -1,7 +1,10 @@
 package balancetalk.member.dto;
 
+import static balancetalk.member.domain.SignupType.*;
+
 import balancetalk.member.domain.Member;
 import balancetalk.member.domain.Role;
+import balancetalk.member.domain.SignupType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -54,12 +57,16 @@ public class MemberDto {
         @Schema(description = "회원 권한", example = "USER")
         private Role role;
 
+        @Schema(description = "회원 가입 경로", example = "STANDARD")
+        private SignupType signupType;
+
         public Member toEntity() {
             return Member.builder()
                     .nickname(nickname)
                     .email(email)
                     .password(password)
                     .role(role)
+                    .signupType(STANDARD)
                     .profileImgId(profileImgId)
                     .build();
         }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 회원가입 여부를 구분하는 `signup_type` 필드 추가
- [x] 중복된 이메일로 회원가입 처리 방지
- [x] 소셜로그인 리다이렉트 처리

## 💡 자세한 설명

소셜 로그인으로 가입한 사용자와 일반 회원가입 사용자를 구분하기 위해 `SignupType` Enum 클래스를 생성했습니다.
소셜 로그인 가입자는 `SOCIAL`, 일반 사용자는 `STANDARD`으로 구분합니다.

해당값을 추가한 이유는 회원정보 수정 시 비밀번호를 요구하는데, 소셜 로그인은 회원가입 시 비밀번호를 입력하지 않기 때문에 임의 값을 해쉬화하여 저장하고 있습니다. 이런 문제 때문에, 프론트 쪽에서 `SOCIAL` 사용자인 경우에 비밀번호 검증 과정을 생략하고 회원 정보 수정을 할 수 있도록 구현 예정입니다.

또한, 현재는 naver나 kakao로 가입 시에 `naver_email~`, `kakao_email~` 이런식으로 저장하여 중복된 데이터가 DB에 저장되지 않도록 구현했습니다. 이제는, 하나의 이메일 값으로 DB에 저장을 하며 해당 이메일로 가입된 이력이 존재할 때 에러 모달을 띄워줄 예정입니다.

<img width="524" alt="스크린샷 2024-12-13 오후 3 56 22" src="https://github.com/user-attachments/assets/15a1067d-7ef7-4942-bd69-8afc49e831ea" />

해당 이메일로 가입된 이력이 있을 때, `alreadyRegistered`로 리다이렉트를 시켜줘 프론트 쪽에서 해당 값을 가지고 처리합니다. 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #801 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 사용자 인증 후 동적으로 사용자별 리다이렉트 URL 처리 기능 추가.
	- 사용자 가입 유형을 나타내는 새로운 필드 `signupType` 추가.
	- `SignupType` 열거형 추가로 회원 가입 방법 분류 기능 제공.

- **Bug Fixes**
	- 사용자 이메일 조회 로직 간소화 및 리다이렉트 URL 처리 개선.

- **Documentation**
	- API 문서화에 대한 메타데이터 추가.

- **Chores**
	- 서브프로젝트 커밋 식별자 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->