### PR TITLE
밸런스 게임 조회 시 파일 id 필드 추가 

### DIFF
--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -221,8 +221,9 @@ public class GameDto {
     public static List<GameOptionDto> getGameOptionDtos(Game game, Map<Long, String> gameOptionImgUrls) {
         return game.getGameOptions().stream()
                 .map(option -> {
+                    Long fileId = option.getImgId();
                     String imgUrl = gameOptionImgUrls.get(option.getId());
-                    return GameOptionDto.fromEntity(option, imgUrl);
+                    return GameOptionDto.fromEntity(option, fileId, imgUrl);
                 })
                 .toList();
     }

--- a/src/main/java/balancetalk/game/dto/GameOptionDto.java
+++ b/src/main/java/balancetalk/game/dto/GameOptionDto.java
@@ -35,10 +35,11 @@ public class GameOptionDto {
     @Schema(description = "선택지", example = "A")
     private VoteOption optionType;
 
-    public static GameOptionDto fromEntity(GameOption gameOption, String imgUrl) {
+    public static GameOptionDto fromEntity(GameOption gameOption, Long fileId, String imgUrl) {
         return GameOptionDto.builder()
                 .id(gameOption.getId())
                 .name(gameOption.getName())
+                .fileId(fileId)
                 .imgUrl(imgUrl)
                 .description(gameOption.getDescription())
                 .optionType(gameOption.getOptionType())

--- a/src/main/java/balancetalk/game/dto/TempGameDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameDto.java
@@ -59,8 +59,9 @@ public class TempGameDto {
     ) {
         return tempGame.getTempGameOptions().stream()
                 .map(option -> {
+                    Long fileId = option.getImgId();
                     String imgUrl = tempGameOptionImgUrls.get(option.getId());
-                    return TempGameOptionDto.fromEntity(option, option.getImgId(), imgUrl);
+                    return TempGameOptionDto.fromEntity(option, fileId, imgUrl);
                 })
                 .toList();
     }

--- a/src/main/java/balancetalk/game/dto/TempGameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/TempGameSetDto.java
@@ -15,7 +15,7 @@ import lombok.Builder;
 import lombok.Data;
 
 public class TempGameSetDto {
-    
+
     @Data
     public static class CreateTempGameSetRequest {
 

--- a/src/main/resources/logs/log4j2-prod.yml
+++ b/src/main/resources/logs/log4j2-prod.yml
@@ -33,7 +33,7 @@ Configuration:
       AppenderRef:
         ref: RollingFile_Appender
     Logger:
-      name: balancetalk-prod
+      name: picko-prod
       additivity: false
       level: info
       includeLocation: false

--- a/src/main/resources/logs/log4j2-prod.yml
+++ b/src/main/resources/logs/log4j2-prod.yml
@@ -1,0 +1,41 @@
+Configuration:
+  name: Logger-prod
+  status: info
+
+  Appenders:
+    RollingFile:
+      name: RollingFile_Appender
+      fileName: ${sys:LOG_DIR}/logfile.log
+      filePattern: "${sys:LOG_DIR}/logfile-%d{yyyy-MM-dd}.%i.txt"
+      PatternLayout:
+        pattern: "%style{%d{yyyy-MM-dd HH:mm:ss.SSS}{GMT+9}}{cyan} %highlight{[%-5p]}{FATAL=bg_red,
+            ERROR=red, INFO=green, DEBUG=blue, TRACE=bg_yellow} [%C] %style{[%t]}{yellow}- %m%n"
+      # immediateFlush: false   # async 방식으로 버퍼를 통해 로그 남기기
+
+      Policies:
+        SizeBasedTriggeringPolicy:
+          size: "10 MB"
+        TimeBasedTriggeringPolicy:
+          Interval: 1   # 하루마다 rollover 발생
+          modulate: true
+
+      DefaultRollOverStrategy:
+        max: 10
+        Delete:
+          basePath: ${sys:LOG_DIR}
+          maxDepth: "1"   # 디렉토리 깊이
+          IfLastModified:
+            age: "P7D"   # 파일을 7일동안 보관
+
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: RollingFile_Appender
+    Logger:
+      name: balancetalk-prod
+      additivity: false
+      level: info
+      includeLocation: false
+      AppenderRef:
+        ref: RollingFile_Appender


### PR DESCRIPTION
## 💡 작업 내용
- [x] fileId 필드 추가
- [x] log4j2-prod 파일 추가
- [x] prod yml 로그 경로를 dev -> prod로 변경

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #818 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- `GameOptionDto`에 `fileId` 매개변수를 추가하여 게임 옵션 데이터의 생성 방식을 개선했습니다.
	- `CreateTempGameSetRequest` 클래스에 `isNewRequest()` 메서드를 추가하여 요청의 새 여부를 확인할 수 있게 했습니다.
	- 새로운 로깅 구성 파일 `log4j2-prod.yml`을 추가하여 프로덕션 환경에서의 로깅 설정을 정의했습니다.
	- 서브프로젝트 커밋 ID가 업데이트되었습니다.

- **Bug Fixes**
	- `getTempGameOptionDtos` 메서드의 내부 로직을 수정하여 이미지 ID를 명확하게 처리하도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->