### PR TITLE
톡픽 답글 작성 불가 이슈 해결

### DIFF
--- a/src/main/java/balancetalk/comment/dto/CommentDto.java
+++ b/src/main/java/balancetalk/comment/dto/CommentDto.java
@@ -45,6 +45,7 @@ public class CommentDto {
                     .isBest(false)
                     .viewStatus(ViewStatus.NORMAL)
                     .parent(parent)
+                    .editedAt(LocalDateTime.now())
                     .isEdited(false)
                     .build();
         }


### PR DESCRIPTION
## 💡 작업 내용
- [x] `CommentDto` 에서 답글 생성 시 `editedAt` 필드 부여

## 💡 자세한 설명
기존에 일반 댓글 생성시에만 부여했던 `editedAt` 필드를 답글 생성시에도 부여하도록 수정했습니다. 
## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #817


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 댓글 생성 시 부모 댓글을 참조할 수 있는 기능 추가.
	- 댓글 생성 시 수정된 시간 자동 기록.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->