### PR TITLE
토큰 재발급 로직 리팩토링 

### DIFF
--- a/src/main/java/balancetalk/global/exception/ErrorCode.java
+++ b/src/main/java/balancetalk/global/exception/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
     NOT_FOUND_TEMP_TALK_PICK(NOT_FOUND, "임시 저장한 톡픽이 존재하지 않습니다."),
     NOT_FOUND_NOTIFICATION(NOT_FOUND, "존재하지 않는 알림입니다."),
     NOT_FOUND_GAME_OPTION(NOT_FOUND, "게임 선택지가 존재하지 않습니다."),
+    NOT_FOUND_CACHE_VALUE(NOT_FOUND, "캐시 값이 존재하지 않습니다."),
 
     // 409
     ALREADY_VOTE(CONFLICT, "이미 투표한 게시글입니다."),

--- a/src/main/java/balancetalk/member/presentation/MemberController.java
+++ b/src/main/java/balancetalk/member/presentation/MemberController.java
@@ -6,7 +6,6 @@ import balancetalk.member.dto.ApiMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -74,8 +73,8 @@ public class MemberController {
 
     @GetMapping("/reissue")
     @Operation(summary = "액세스 토큰 재발급", description = "만료된 액세스 토큰을 재발급 받는다.")
-    public String reissueAccessToken(HttpServletRequest request) {
-        return memberService.reissueAccessToken(request);
+    public String reissueAccessToken(@Parameter(hidden = true) @AuthPrincipal ApiMember apiMember) {
+        return memberService.reissueAccessToken(apiMember);
     }
 
     @PutMapping


### PR DESCRIPTION
## 💡 작업 내용
- [x] 캐시를 통해 회원 토큰 값 유효성 검사
- [x] 에러 코드 추가

## 💡 자세한 설명
기존에는 HttpServletRequest를 통해서 쿠키를 가져오고 유효성 검사를 진행했는데, 캐시를 통해 유효성 검사를 하도록 수정했습니다.

<img width="571" alt="스크린샷 2024-12-23 오후 5 17 14" src="https://github.com/user-attachments/assets/55f622aa-c877-45a4-b962-ebe96ff39024" />

로그인을 할 때 {회원 id, RefreshToken} 형태로 캐시에 저장합니다.

<img width="685" alt="스크린샷 2024-12-23 오후 5 18 04" src="https://github.com/user-attachments/assets/952b4f63-0403-476b-8a33-6df6da9c19ae" />

따라서, 재발급 로직에서 회원 id를 통해서 리프레시 토큰을 가져오고, 유효성 검사를 진행한 후에 유효한 경우에만 새로운 액세스 토큰을 재발급 해주도록 수정했습니다.


---
```
RefreshToken("refreshToken", 604800000, 10000)
```

캐시에 저장되는 리프레시 토큰의 만료 기간은 7일, maximumSize는 10000으로 고정했습니다.
## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #825 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 캐시 값이 존재하지 않을 때를 위한 새로운 오류 코드 `NOT_FOUND_CACHE_VALUE` 추가.
	- `reissueAccessToken` 메서드가 `HttpServletRequest` 대신 `ApiMember` 객체를 사용하도록 변경.
  
- **버그 수정**
	- 캐시에서 값이 없을 경우 새로운 오류 코드로 예외 처리.

- **문서화**
	- `apiMember` 매개변수에 대한 API 문서에서 숨김 처리 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->