### PR TITLE
일반 회원이 소셜 로그인 가입 클릭 시 홈으로 리다이렉트

### DIFF
--- a/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
@@ -73,6 +73,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .email(findMember.getEmail())
                     .role(findMember.getRole())
                     .build();
+            if (findMember.getSignupType() == STANDARD) { // 일반 회원일 때 소셜 로그인 클릭 시, 홈으로 리다이렉트
+                return new CustomOAuth2User(oauth2Dto, firstRegisterUrl);
+            }
             return new CustomOAuth2User(oauth2Dto, alreadyRegisteredUrl);
         }
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 소셜 로그인 로직 수정

## 💡 자세한 설명

소셜 로그인으로 회원 가입 시, 두가지 분기 처리를 해주고 있었습니다.

<img width="610" alt="스크린샷 2025-01-01 오후 6 19 08" src="https://github.com/user-attachments/assets/e3d8f821-313c-4cab-9a17-0496539fd2b0" />


DB에서 조회하여 회원이 없는 경우엔, 새 회원을 DB에 저장하고 홈으로 리다이렉트 하도록 구현했습니다.

회원이 있는 경우엔, 해당 회원 정보만 반환값으로 리턴하고 회원이 존재하기 때문에 `https://pick0.com?status=already_registered`로 리다이렉트 하도록 구현했습니다.

---

현재 문제가 됐던 부분은, 일반 회원가입으로 가입한 뒤 동일한 이메일 주소로 소셜 회원가입을 클릭했을 때 역시 `https://pick0.com?status=already_registered` 로 리다이렉트를 해주고 있었습니다.

따라서, 해당 회원이 일반 회원가입을 진행했다면, 홈으로 리다이렉트 되도록 한번 더 분기 처리를 해줬습니다.

<img width="730" alt="스크린샷 2025-01-01 오후 6 23 24" src="https://github.com/user-attachments/assets/bb297e49-ee46-4f55-9f59-f7802576c1e1" />




## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #833 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 소셜 로그인 후 회원 가입 유형에 따라 다른 리다이렉션 로직 추가
	- 표준 회원과 기존 회원에 대한 로그인 흐름 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->