### PR TITLE
비동기 메서드에서 엔티티 객체를 직접 조회하도록 수정하여 트랜잭션 반영 문제 해결

### DIFF
--- a/src/main/java/balancetalk/talkpick/application/TalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickService.java
@@ -43,7 +43,7 @@ public class TalkPickService {
             talkPickFileHandler.handleFilesOnTalkPickCreate(request.getFileIds(), savedTalkPickId);
         }
 
-        talkPickSummarizer.summary(savedTalkPick);
+        talkPickSummarizer.summary(savedTalkPickId);
 
         return savedTalkPickId;
     }
@@ -87,7 +87,7 @@ public class TalkPickService {
         talkPick.update(request.toEntity(member));
         talkPickFileHandler
                 .handleFilesOnTalkPickUpdate(request.getNewFileIds(), request.getDeleteFileIds(), talkPickId);
-        talkPickSummarizer.summary(talkPick);
+        talkPickSummarizer.summary(talkPickId);
     }
 
     @Transactional


### PR DESCRIPTION
## 💡 작업 내용
- [x] summary 메서드의 파라미터를 TalkPick에서 TalkPickId로 변경

## 💡 자세한 설명
톡픽 생성과 요약은 서로 다른 트랜잭션에서 실행됩니다.
톡픽 생성 트랜잭션에서 가져온 TalkPick 엔티티는 새로운 트랜잭션(톡픽 요약)에서 detached 상태가 되어 영속성 컨텍스트에 의해 관리되지 않습니다.
이로 인해 JPA가 해당 엔티티의 변경을 추적하지 못해 데이터베이스에 반영되지 않는 문제가 발생했습니다.

이를 해결하기 위해 summary 메서드가 TalkPickId를 받아 비동기 트랜잭션 내부에서 엔티티를 조회하도록 수정했습니다.
이 방식으로 summary 메서드 내부에서 조회된 TalkPick 엔티티는 새로운 트랜잭션의 영속성 컨텍스트에 포함되어 변경 사항이 올바르게 반영됩니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #836 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
	- 토크픽 요약 로직의 입력 방식 변경
	- 토크픽 ID를 사용하여 요약 프로세스 개선
	- 레포지토리를 통한 토크픽 데이터 조회 메커니즘 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->