### PR TITLE
스케줄링을 통해 요약에 실패한 톡픽들에 대한 요약 작업 재수행 기능 구현

### DIFF
--- a/src/main/java/balancetalk/talkpick/application/TalkPickScheduleService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickScheduleService.java
@@ -2,12 +2,14 @@ package balancetalk.talkpick.application;
 
 import static balancetalk.talkpick.domain.SummaryStatus.FAIL;
 
+import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.TalkPickSummarizer;
 import balancetalk.talkpick.domain.repository.TalkPickRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +17,7 @@ public class TalkPickScheduleService {
 
     private final TalkPickRepository talkPickRepository;
     private final TalkPickSummarizer talkPickSummarizer;
+    private final TodayTalkPickService todayTalkPickService;
 
     @Scheduled(cron = "0 00 00 * * ?")
     public void retryFailedSummaries() {
@@ -22,5 +25,10 @@ public class TalkPickScheduleService {
         for (Long summaryFailedTalkPickId : summaryFailedTalkPickIds) {
             talkPickSummarizer.summarizeTalkPick(summaryFailedTalkPickId);
         }
+    }
+
+    @Scheduled(cron = "0 00 00 * * ?")
+    public void updateTodayTalkPick() {
+        todayTalkPickService.updateTodayTalkPick();
     }
 }

--- a/src/main/java/balancetalk/talkpick/application/TalkPickScheduleService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickScheduleService.java
@@ -1,0 +1,26 @@
+package balancetalk.talkpick.application;
+
+import static balancetalk.talkpick.domain.SummaryStatus.FAIL;
+
+import balancetalk.talkpick.domain.TalkPickSummarizer;
+import balancetalk.talkpick.domain.repository.TalkPickRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TalkPickScheduleService {
+
+    private final TalkPickRepository talkPickRepository;
+    private final TalkPickSummarizer talkPickSummarizer;
+
+    @Scheduled(cron = "0 00 00 * * ?")
+    public void retryFailedSummaries() {
+        List<Long> summaryFailedTalkPickIds = talkPickRepository.findIdsBySummaryStatus(FAIL);
+        for (Long summaryFailedTalkPickId : summaryFailedTalkPickIds) {
+            talkPickSummarizer.summarizeTalkPick(summaryFailedTalkPickId);
+        }
+    }
+}

--- a/src/main/java/balancetalk/talkpick/application/TalkPickScheduleService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickScheduleService.java
@@ -17,7 +17,7 @@ public class TalkPickScheduleService {
     private final TalkPickSummarizer talkPickSummarizer;
     private final TodayTalkPickService todayTalkPickService;
 
-    @Scheduled(cron = "0 00 00 * * ?")
+    @Scheduled(cron = "0 30 00 * * ?")
     public void retryFailedSummaries() {
         List<Long> summaryFailedTalkPickIds = talkPickRepository.findIdsBySummaryStatus(FAIL);
         for (Long summaryFailedTalkPickId : summaryFailedTalkPickIds) {

--- a/src/main/java/balancetalk/talkpick/application/TalkPickScheduleService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickScheduleService.java
@@ -2,14 +2,12 @@ package balancetalk.talkpick.application;
 
 import static balancetalk.talkpick.domain.SummaryStatus.FAIL;
 
-import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.domain.TalkPickSummarizer;
 import balancetalk.talkpick.domain.repository.TalkPickRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/balancetalk/talkpick/application/TalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickService.java
@@ -43,7 +43,7 @@ public class TalkPickService {
             talkPickFileHandler.handleFilesOnTalkPickCreate(request.getFileIds(), savedTalkPickId);
         }
 
-        talkPickSummarizer.summary(savedTalkPickId);
+        talkPickSummarizer.summarizeTalkPick(savedTalkPickId);
 
         return savedTalkPickId;
     }
@@ -87,7 +87,7 @@ public class TalkPickService {
         talkPick.update(request.toEntity(member));
         talkPickFileHandler
                 .handleFilesOnTalkPickUpdate(request.getNewFileIds(), request.getDeleteFileIds(), talkPickId);
-        talkPickSummarizer.summary(talkPickId);
+        talkPickSummarizer.summarizeTalkPick(talkPickId);
     }
 
     @Transactional

--- a/src/main/java/balancetalk/talkpick/application/TodayTalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TodayTalkPickService.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,9 +28,8 @@ public class TodayTalkPickService {
     @Value("${pick-o.today-talk-pick-count}")
     private int todayTalkPickCount;
 
-    @Scheduled(cron = "0 0 0 * * ?")
     @Transactional
-    public void createTodayTalkPick() {
+    public void updateTodayTalkPick() {
         List<TalkPick> candidateTodayTalkPicks = getCandidateTodayTalkPicks();
         Collections.shuffle(candidateTodayTalkPicks);
         List<TodayTalkPick> todayTalkPicks = candidateTodayTalkPicks.subList(0, todayTalkPickCount)

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepository.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepository.java
@@ -4,7 +4,6 @@ import balancetalk.talkpick.domain.TalkPick;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.List;
 
 public interface TalkPickRepository extends JpaRepository<TalkPick, Long>, TalkPickRepositoryCustom {
 

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryCustom.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryCustom.java
@@ -2,6 +2,7 @@ package balancetalk.talkpick.domain.repository;
 
 import static balancetalk.talkpick.dto.TalkPickDto.TalkPickResponse;
 
+import balancetalk.talkpick.domain.SummaryStatus;
 import balancetalk.talkpick.domain.TalkPick;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -14,4 +15,6 @@ public interface TalkPickRepositoryCustom {
     Page<TalkPickResponse> findPagedTalkPicks(Pageable pageable);
 
     List<TalkPickResponse> findBestTalkPicks();
+
+    List<Long> findIdsBySummaryStatus(SummaryStatus summaryStatus);
 }

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepositoryImpl.java
@@ -5,6 +5,7 @@ import static balancetalk.talkpick.domain.QTalkPick.talkPick;
 import static balancetalk.talkpick.dto.TalkPickDto.TalkPickResponse;
 import static balancetalk.vote.domain.QTalkPickVote.talkPickVote;
 
+import balancetalk.talkpick.domain.SummaryStatus;
 import balancetalk.talkpick.domain.TalkPick;
 import balancetalk.talkpick.dto.QTalkPickDto_TalkPickResponse;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -62,6 +63,14 @@ public class TalkPickRepositoryImpl implements TalkPickRepositoryCustom {
                 .from(talkPick)
                 .orderBy(talkPick.views.desc(), talkPick.createdAt.desc())
                 .limit(3)
+                .fetch();
+    }
+
+    @Override
+    public List<Long> findIdsBySummaryStatus(SummaryStatus summaryStatus) {
+        return queryFactory.select(talkPick.id)
+                .from(talkPick)
+                .where(talkPick.summaryStatus.eq(summaryStatus))
                 .fetch();
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] `@Retryable` 제거 및 예외 처리, 메서드 네이밍 개선
- [x] `@Scheduled`를 통해 요약에 실패한 톡픽들에 대한 요약 작업 재수행 기능 구현
- [x] 오늘의 톡픽 업데이트의 `@Scheduled` 위치 변경 및 메서드 네이밍 개선
- [x] 요약 재수행 작업 시작 시간 00시 30분으로 변경

## 💡 자세한 설명
### `@Retryable` 제거 및 예외 처리
`@Recover`가 정상 동작하지 않는 문제로 인해 `@Retryable`를 임시 제거했습니다. 
다음 이슈에서 처리할 예정입니다.

### 요약 재수행 작업 시작 시간 변경
스케줄링 작업이 오늘의 톡픽 업데이트 작업보다 먼저 실행되는 것을 방지하고자 요약 재수행 작업의 시작 시간을 00시 30분으로 변경했습니다.
이를 통해 긴 시간이 걸리는 요약 작업으로 인해 오늘의 톡픽 업데이트 작업이 지연되는 문제를 방지할 수 있을 것으로 기대합니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #839 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 실패한 요약 재시도 및 오늘의 대화 픽 자동 업데이트를 위한 예약 작업 추가
	- 대화 픽 요약 프로세스의 오류 처리 개선

- **버그 수정**
	- 대화 픽 요약 중 발생하는 오류에 대한 로깅 및 상태 관리 강화

- **리팩토링**
	- 메서드 이름 및 구조를 더 명확하고 의미 있게 변경
	- 요약 생성 로직의 내부 구조 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->