### PR TITLE
ThreadPoolTaskExecutor의 corePoolSize를 2로 설정

### DIFF
--- a/src/main/java/balancetalk/global/config/AsyncConfig.java
+++ b/src/main/java/balancetalk/global/config/AsyncConfig.java
@@ -3,6 +3,7 @@ package balancetalk.global.config;
 import balancetalk.global.exception.CustomAsyncUncaughtExceptionHandler;
 import java.util.concurrent.Executor;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -12,9 +13,13 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @Configuration
 public class AsyncConfig implements AsyncConfigurer {
 
+    @Value("${async.executor.corePoolSize}")
+    private int corePoolSize;
+
     @Override
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
         executor.setThreadNamePrefix("Async task - ");
         executor.initialize();
         return executor;

--- a/src/main/java/balancetalk/global/config/AsyncConfig.java
+++ b/src/main/java/balancetalk/global/config/AsyncConfig.java
@@ -13,7 +13,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @Configuration
 public class AsyncConfig implements AsyncConfigurer {
 
-    @Value("${async.executor.corePoolSize}")
+    @Value("${async.executor.core-pool-size}")
     private int corePoolSize;
 
     @Override


### PR DESCRIPTION
## 💡 작업 내용
- [x] ThreadPoolTaskExecutor의 corePoolSize를 2로 설정

## 💡 자세한 설명
`사용 가능한 코어 개수 * (1 + 대기시간/서비스시간)` 공식을 이용하여 이론적인 적정 스레드 개수를 2로 설정했습니다.
- 사용 가능한 코어 개수 = EC2 프리티어의 CPU 코어 수 = **1**
- 대기 시간 = 스레드가 작업을 처리하기 위해 대기하는 평균 시간 = **약 293ms**
- 서비스 시간 = 스레드가 작업을 처리하는 평균 시간 = **약 2594ms**

이후 테스트와 모니터링을 통해 스레드 풀 크기를 최적화합니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #816 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **구성**
	- 비동기 작업 실행자의 코어 풀 크기를 동적으로 구성할 수 있도록 설정 옵션 추가
	- 외부 설정 파일을 통해 스레드 풀 크기를 유연하게 조정 가능

- **하위 프로젝트**
	- 서브프로젝트 커밋 참조 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->