### PR TITLE
소셜 로그인 리다이렉트 수정

### DIFF
--- a/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/balancetalk/global/oauth2/service/CustomOAuth2UserService.java
@@ -73,10 +73,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .email(findMember.getEmail())
                     .role(findMember.getRole())
                     .build();
-            if (findMember.getSignupType() == STANDARD) { // 일반 회원일 때 소셜 로그인 클릭 시, 홈으로 리다이렉트
-                return new CustomOAuth2User(oauth2Dto, firstRegisterUrl);
+            if (findMember.getSignupType() == STANDARD) { // 일반 회원일 때 소셜 로그인 클릭 시, already_registered로 리다이렉트
+                return new CustomOAuth2User(oauth2Dto, alreadyRegisteredUrl);
             }
-            return new CustomOAuth2User(oauth2Dto, alreadyRegisteredUrl);
+            return new CustomOAuth2User(oauth2Dto, firstRegisterUrl);
         }
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 일반 회원으로 가입한 사용자의 경우, `alreadyRegistered`로 리다이렉트 처리
- [x] 소셜 회원의 경우, `firstRegistered`로 리다이렉트 처리

## 💡 자세한 설명

일반 회원으로 가입한 이메일로 소셜 로그인을 시도할 때, `alreadyRegistered`로 리다이렉트를 하며 쿠키 생성과 토큰 생성을 하지 않아야 했습니다.

현재 코드에선 반대로 되어있어 바꿔주었습니다.

또한, url이 `alreadyRegistered`인 경우에 쿠키 생성과 토큰 생성을 하지않고 return 처리를 추가했습니다.

![제목 없는 다이어그램](https://github.com/user-attachments/assets/b2d72207-6333-470e-9898-58471fee4943)


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #860 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 이미 등록된 사용자에 대한 OAuth2 로그인 리디렉션 로직 개선
	- 사용자의 가입 유형에 따른 맞춤형 리디렉션 처리 추가

- **버그 수정**
	- OAuth2 로그인 시 사용자 리디렉션 프로세스의 정확성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->