### PR TITLE
밸런스 게임 조회수가 증가하지 않는 이슈

### DIFF
--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -151,7 +151,7 @@ public class GameService {
         fileHandler.relocateFile(newFile, oldGameOption.getId(), GAME_OPTION);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public GameSetDetailResponse findBalanceGameSet(final Long gameSetId, final GuestOrApiMember guestOrApiMember) {
         GameSet gameSet = gameSetRepository.findById(gameSetId)
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME_SET));


### PR DESCRIPTION
## 💡 작업 내용
- [x] `@Transactional(readOnly = true)`에서 readOnly 옵션 제거

## 💡 자세한 설명

기존에 `readOnly = true` 라는 조건을 붙이면서 게임을 조회할 때 update 쿼리가 실행되지 않았습니다.

따라서, views 필드가 조회를 해도 업데이트 되지 않고 그대로 0으로 남아있는 오류가 발생했습니다.


```
Hibernate: 
    select
        gs1_0.id,
        gs1_0.bookmarks,
        gs1_0.created_at,
        gs1_0.edited_at,
        gs1_0.last_modified_at,
        gs1_0.main_tag_id,
        gs1_0.member_id,
        gs1_0.notification_history_json,
        gs1_0.sub_tag,
        gs1_0.title,
        gs1_0.views 
    from
        game_set gs1_0 
    where
        gs1_0.id=?
...
Hibernate: 
    update
        game_set 
    set
        bookmarks=?,
        edited_at=?,
        last_modified_at=?,
        main_tag_id=?,
        member_id=?,
        notification_history_json=?,
        sub_tag=?,
        title=?,
        views=? 
    where
        id=?
```

`@Transactional`로 변경함에 따라 성공적으로 업데이트 쿼리가 나가는 것을 확인했습니다. 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #862 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 변경**
	- 게임셋 조회 메서드의 트랜잭션 관리 방식 업데이트
	- 읽기 전용 트랜잭션에서 표준 트랜잭션으로 변경
	- 데이터베이스 상호작용 방식에 잠재적 변경사항 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->