### PR TITLE
밸런스 게임 작성자 필드값 추가 

### DIFF
--- a/src/main/java/balancetalk/game/domain/Game.java
+++ b/src/main/java/balancetalk/game/domain/Game.java
@@ -49,6 +49,10 @@ public class Game extends BaseTimeEntity {
 
     private LocalDateTime editedAt;
 
+    public Long getWriterId() {
+        return gameSet.getWriterId();
+    }
+
     public long getVoteCount(VoteOption optionType) {
         GameOption option = gameOptions.stream()
                 .filter(gameOption -> gameOption.isTypeEqual(optionType))

--- a/src/main/java/balancetalk/game/domain/GameSet.java
+++ b/src/main/java/balancetalk/game/domain/GameSet.java
@@ -92,6 +92,10 @@ public class GameSet extends BaseTimeEntity {
         return games.stream().anyMatch(game -> game.getId().equals(gameId));
     }
 
+    public Long getWriterId() {
+        return member.getId();
+    }
+
     public void addGames(List<Game> games) {
         this.games = games;
         games.forEach(game -> {

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -147,6 +147,9 @@ public class GameDto {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class GameMyPageResponse {
 
+        @Schema(description = "작성자 id", example = "1")
+        private Long writerId;
+
         @Schema(description = "밸런스 게임 세트 ID", example = "1")
         private long gameSetId;
 
@@ -180,6 +183,7 @@ public class GameDto {
 
         public static GameMyPageResponse from(GameSet gameSet, String imgA, String imgB) {
             return GameMyPageResponse.builder()
+                    .writerId(gameSet.getWriterId())
                     .gameSetId(gameSet.getId())
                     .title(gameSet.getTitle())
                     .optionAImg(imgA)
@@ -192,6 +196,7 @@ public class GameDto {
 
         public static GameMyPageResponse from(Game game, GameBookmark bookmark, String imgA, String imgB) {
             return GameMyPageResponse.builder()
+                    .writerId(game.getWriterId())
                     .gameSetId(game.getGameSet().getId())
                     .gameId(game.getId())
                     .title(game.getGameSet().getTitle())
@@ -206,6 +211,7 @@ public class GameDto {
 
         public static GameMyPageResponse from(Game game, GameVote vote, String imgA, String imgB) {
             return GameMyPageResponse.builder()
+                    .writerId(game.getWriterId())
                     .gameId(game.getId())
                     .title(game.getGameSet().getTitle())
                     .optionAImg(imgA)

--- a/src/main/java/balancetalk/game/dto/GameSetDto.java
+++ b/src/main/java/balancetalk/game/dto/GameSetDto.java
@@ -72,6 +72,9 @@ public class GameSetDto {
     @Schema(description = "밸런스 게임 세트 목록 조회 응답")
     public static class GameSetResponse {
 
+        @Schema(description = "작성자 id", example = "1")
+        private Long writerId;
+
         @Schema(description = "밸런스 게임 세트 id", example = "1")
         private Long id;
 
@@ -90,6 +93,7 @@ public class GameSetDto {
 
         public static GameSetResponse fromEntity(GameSet gameSet, Member member, List<String> images) {
             return GameSetResponse.builder()
+                    .writerId(gameSet.getWriterId())
                     .id(gameSet.getId())
                     .title(gameSet.getTitle())
                     .mainTag(gameSet.getMainTag().getName())

--- a/src/main/java/balancetalk/game/dto/SearchGameResponse.java
+++ b/src/main/java/balancetalk/game/dto/SearchGameResponse.java
@@ -14,6 +14,9 @@ import lombok.Data;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SearchGameResponse {
 
+    @Schema(description = "작성자 id", example = "1")
+    private Long writerId;
+
     @Schema(description = "밸런스 게임 ID", example = "1")
     private long id;
 
@@ -37,6 +40,7 @@ public class SearchGameResponse {
 
     public static SearchGameResponse from(Game game, String imgA, String imgB) {
         return SearchGameResponse.builder()
+                .writerId(game.getWriterId())
                 .gameSetId(game.getGameSet().getId())
                 .id(game.getId())
                 .title(game.getGameSet().getTitle())


### PR DESCRIPTION
## 💡 작업 내용
- [x] 응답 필드값으로 `writerId` 추가

## 💡 자세한 설명


#### 마이페이지

![스크린샷 2025-01-15 오전 1 44 15](https://github.com/user-attachments/assets/e4e739d4-f441-4dbf-b9a1-841144903bf8)

#### 검색 결과 페이지

![스크린샷 2025-01-15 오전 1 46 33](https://github.com/user-attachments/assets/edf45662-b95e-44bc-9b0e-84ca30307d9d)

### 랜딩페이지 및 주제별 밸런스 게임 페이지

메인 태그 유무 (O)
- 최신순으로 게임 세트 조회 
- 인기순으로 게임 세트 조회

메인 태그 (X)
- 인기순으로 게임 세트 조회

![스크린샷 2025-01-15 오전 1 47 19](https://github.com/user-attachments/assets/31573754-de09-445f-8001-1c3c58e0afbf)


프론트 요청에 따라 다음과 같은 API들에 게시글 작성자 정보를 추가했습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #858 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 게임 및 게임셋의 작성자 ID를 조회할 수 있는 기능 추가
	- 다양한 게임 관련 응답 DTO에 작성자 ID 필드 도입

- **개선 사항**
	- 게임 및 게임셋 관련 API 응답에 작성자 정보 포함
	- 검색, 마이페이지, 게임셋 응답에 작성자 ID 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->