### PR TITLE
내가 투표한 게임 조회 시 gameSetId가 모두 0으로 통일되는 버그 해결

### DIFF
--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -212,6 +212,7 @@ public class GameDto {
         public static GameMyPageResponse from(Game game, GameVote vote, String imgA, String imgB) {
             return GameMyPageResponse.builder()
                     .writerId(game.getWriterId())
+                    .gameSetId(game.getGameSet().getId())
                     .gameId(game.getId())
                     .title(game.getGameSet().getTitle())
                     .optionAImg(imgA)


### PR DESCRIPTION
## 💡 작업 내용
- [x] 내가 투표한 게임 응답 반환 시 gameSetId 포함 반환

## 💡 자세한 설명
반환 빌더 메서드에서 `gameSetId` 필드를 포함하지 않기 때문에 발생한 버그였습니다.
해당 빌더 메서드에 `gameSetId` 필드를 반환하도록 수정함으로서, 버그를 픽스했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #873 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 게임 세트 ID를 응답에 포함하여 게임 정보의 상세 정보를 개선했습니다.

- **버그 수정**
	- 게임 페이지 응답에서 누락된 게임 세트 ID 정보를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->