### PR TITLE
내가 투표한 밸런스게임 조회 시 이슈 발생 해결

### DIFF
--- a/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
+++ b/src/main/java/balancetalk/bookmark/application/BookmarkGameService.java
@@ -97,7 +97,7 @@ public class BookmarkGameService {
                             increaseBookmarkCountForActivation(bookmark, gameSet);
                             bookmark.activate();
                             bookmark.setIsEndGameSet(true); // 밸런스게임 세트 종료 표시
-                            voteRepository.deleteAllByMemberIdAndGameOption_Game_GameSet(member.getId(), gameSet);
+                            voteRepository.updateVotesAsInactive(member.getId(), gameSet);
                             bookmark.updateGameId(gameId); //gameId도 업데이트
                         },
                         () -> { // resourceId가 gameSetId와 일치하는 북마크가 없다면 새로 생성

--- a/src/main/java/balancetalk/game/domain/repository/GameRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameRepository.java
@@ -84,7 +84,7 @@ public interface GameRepository extends JpaRepository<Game, Long> {
               JOIN go2.game g3 
               WHERE gv2.member.id = :memberId 
               AND g3.gameSet.id = g.gameSet.id) DESC
-""")
+        """)
     List<Game> findLatestVotedGamesByMember(@Param("memberId") Long memberId);
 
 }

--- a/src/main/java/balancetalk/game/domain/repository/GameRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameRepository.java
@@ -1,6 +1,7 @@
 package balancetalk.game.domain.repository;
 
 import balancetalk.game.domain.Game;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -66,4 +67,24 @@ public interface GameRepository extends JpaRepository<Game, Long> {
             @Param("sort") String sort,
             Pageable pageable
     );
+
+    @Query("""
+    SELECT g FROM Game g
+    WHERE g.id = (
+        SELECT g2.id FROM GameVote gv
+        JOIN gv.gameOption go
+        JOIN go.game g2
+        WHERE gv.member.id = :memberId
+        AND g2.gameSet.id = g.gameSet.id
+        ORDER BY gv.createdAt DESC
+        LIMIT 1
+    )
+    ORDER BY (SELECT MAX(gv2.createdAt) FROM GameVote gv2 
+              JOIN gv2.gameOption go2 
+              JOIN go2.game g3 
+              WHERE gv2.member.id = :memberId 
+              AND g3.gameSet.id = g.gameSet.id) DESC
+""")
+    List<Game> findLatestVotedGamesByMember(@Param("memberId") Long memberId);
+
 }

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -181,7 +181,7 @@ public class GameDto {
         @Schema(description = "밸런스 게임 메인 태그 이름", example = "인기")
         private String mainTagName;
 
-        public static GameMyPageResponse from(GameSet gameSet, String imgA, String imgB) {
+        public static GameMyPageResponse from(GameSet gameSet, GameBookmark gameBookmark, String imgA, String imgB) {
             return GameMyPageResponse.builder()
                     .writerId(gameSet.getWriterId())
                     .gameSetId(gameSet.getId())
@@ -190,6 +190,7 @@ public class GameDto {
                     .optionBImg(imgB)
                     .subTag(gameSet.getSubTag())
                     .mainTagName(gameSet.getMainTag().getName())
+                    .isBookmarked(isBookmarkedAndNotNull(gameBookmark))
                     .editedAt(gameSet.getEditedAt())
                     .build();
         }
@@ -209,7 +210,7 @@ public class GameDto {
                     .build();
         }
 
-        public static GameMyPageResponse from(Game game, GameVote vote, String imgA, String imgB) {
+        public static GameMyPageResponse from(Game game, GameBookmark gameBookmark, GameVote vote, String imgA, String imgB) {
             return GameMyPageResponse.builder()
                     .writerId(game.getWriterId())
                     .gameSetId(game.getGameSet().getId())
@@ -220,8 +221,14 @@ public class GameDto {
                     .voteOption(vote.getVoteOption())
                     .subTag(game.getGameSet().getSubTag())
                     .mainTagName(game.getGameSet().getMainTag().getName())
+                    .isBookmarked(isBookmarkedAndNotNull(gameBookmark))
                     .editedAt(game.getEditedAt())
                     .build();
+        }
+
+
+        private static boolean isBookmarkedAndNotNull(GameBookmark gameBookmark) {
+            return (gameBookmark != null) && gameBookmark.isActive();
         }
     }
 

--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -210,7 +210,8 @@ public class GameDto {
                     .build();
         }
 
-        public static GameMyPageResponse from(Game game, GameBookmark gameBookmark, GameVote vote, String imgA, String imgB) {
+        public static GameMyPageResponse from(Game game, GameBookmark gameBookmark, GameVote vote,
+                                              String imgA, String imgB) {
             return GameMyPageResponse.builder()
                     .writerId(game.getWriterId())
                     .gameSetId(game.getGameSet().getId())

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -28,6 +28,7 @@ import balancetalk.vote.domain.TalkPickVote;
 import balancetalk.vote.domain.TalkPickVoteRepository;
 import balancetalk.vote.domain.GameVote;
 import balancetalk.vote.domain.VoteRepository;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
@@ -135,16 +136,22 @@ public class MyPageService {
 
         List<GameMyPageResponse> responses = latestGames.stream()
                 .map(game -> {
-                    GameVote vote = voteRepository.findFirstByMemberIdAndGameOptionIdIn(
+                    GameVote vote = voteRepository.findLatestVoteByMemberIdAndGameOptionIds(
                             member.getId(), game.getGameOptions().stream()
                                     .map(GameOption::getId)
                                     .toList()
                     );
 
-                    GameBookmark gameBookmark = gameBookmarkRepository.findByMemberAndGameSetId(member, game.getGameSet().getId())
+                    if (vote == null) {
+                        return null;
+                    }
+
+                    GameBookmark gameBookmark = gameBookmarkRepository.findByMemberAndGameSetId(member,
+                                    game.getGameSet().getId())
                             .orElse(null);
                     return createGameMyPageResponse(game, gameBookmark, vote);
                 })
+                .filter(Objects::nonNull)
                 .toList();
 
 

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -136,7 +136,7 @@ public class MyPageService {
 
         List<GameMyPageResponse> responses = latestGames.stream()
                 .map(game -> {
-                    GameVote vote = voteRepository.findTopByMember_IdAndGameOption_IdInOrderByCreatedAtDesc(
+                    GameVote vote = voteRepository.findTopByMemberIdAndGameOptionIdInOrderByCreatedAtDesc(
                             member.getId(), game.getGameOptions().stream()
                                     .map(GameOption::getId)
                                     .toList()

--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -136,7 +136,7 @@ public class MyPageService {
 
         List<GameMyPageResponse> responses = latestGames.stream()
                 .map(game -> {
-                    GameVote vote = voteRepository.findLatestVoteByMemberIdAndGameOptionIds(
+                    GameVote vote = voteRepository.findTopByMember_IdAndGameOption_IdInOrderByCreatedAtDesc(
                             member.getId(), game.getGameOptions().stream()
                                     .map(GameOption::getId)
                                     .toList()

--- a/src/main/java/balancetalk/vote/domain/GameVote.java
+++ b/src/main/java/balancetalk/vote/domain/GameVote.java
@@ -35,6 +35,8 @@ public class GameVote extends BaseTimeEntity {
     @JoinColumn(name = "game_option_id")
     private GameOption gameOption;
 
+    private boolean isActive;
+
     public VoteOption getVoteOption() {
         return gameOption.getOptionType();
     }
@@ -46,5 +48,9 @@ public class GameVote extends BaseTimeEntity {
 
     public void updateGameOption(GameOption gameOption) {
         this.gameOption = gameOption;
+    }
+
+    public void updateActive(boolean isActive) {
+        this.isActive = isActive;
     }
 }

--- a/src/main/java/balancetalk/vote/domain/VoteRepository.java
+++ b/src/main/java/balancetalk/vote/domain/VoteRepository.java
@@ -2,7 +2,9 @@ package balancetalk.vote.domain;
 
 import balancetalk.game.domain.GameSet;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,10 +14,45 @@ public interface VoteRepository extends JpaRepository<GameVote, Long> {
     @Query("""
     SELECT gv FROM GameVote gv
     WHERE gv.member.id = :memberId
+    AND gv.isActive = true
     AND gv.gameOption.id IN :gameOptionIds
     ORDER BY gv.createdAt DESC
-    LIMIT 1""")
-    GameVote findFirstByMemberIdAndGameOptionIdIn(@Param("memberId") Long memberId,
-                                                  @Param("gameOptionIds") List<Long> gameOptionIds);
-    void deleteAllByMemberIdAndGameOption_Game_GameSet(Long memberId, GameSet gameSet);
-}
+    LIMIT 1
+""")
+    GameVote findFirstByMemberIdAndGameOptionIdIn(@Param("memberId") Long memberId, @Param("gameOptionIds") List<Long> gameOptionIds);
+
+    // [1] "내가 투표한 밸런스게임 목록" 전용: 비활성화 포함 (isActive 조건 제거)
+    @Query("""
+        SELECT gv
+        FROM GameVote gv
+        WHERE gv.member.id = :memberId
+          AND gv.gameOption.id IN :gameOptionIds
+        ORDER BY gv.createdAt DESC
+        LIMIT 1
+    """)
+    GameVote findLatestVoteByMemberIdAndGameOptionIds(
+            @Param("memberId") Long memberId,
+            @Param("gameOptionIds") List<Long> gameOptionIds
+    );
+
+    // [2] 활성화된 투표만 조회 (기존 로직 그대로 사용 - 필요하면 유지)
+    @Query("""
+        SELECT gv
+        FROM GameVote gv
+        WHERE gv.member.id = :memberId
+          AND gv.gameOption.game.id = :gameId
+          AND gv.isActive = true
+    """)
+    Optional<GameVote> findActiveVoteByMemberIdAndGameId(@Param("memberId") Long memberId,
+                                                         @Param("gameId") Long gameId);
+
+    @Modifying
+    @Query("""
+        UPDATE GameVote gv SET gv.isActive = false 
+        WHERE gv.member.id = :memberId AND gv.gameOption.game.gameSet = :gameSet
+    """)
+    void updateVotesAsInactive(@Param("memberId") Long memberId, @Param("gameSet") GameSet gameSet);
+
+    // 특정 사용자가 특정 게임에 대해 투표한 기록 조회 (비활성화된 투표도 포함)
+    @Query("SELECT gv FROM GameVote gv WHERE gv.member.id = :memberId AND gv.gameOption.game.id = :gameId")
+    Optional<GameVote> findByMemberIdAndGameId(@Param("memberId") Long memberId, @Param("gameId") Long gameId);}

--- a/src/main/java/balancetalk/vote/domain/VoteRepository.java
+++ b/src/main/java/balancetalk/vote/domain/VoteRepository.java
@@ -12,17 +12,9 @@ import org.springframework.data.repository.query.Param;
 public interface VoteRepository extends JpaRepository<GameVote, Long> {
 
     // [1] "내가 투표한 밸런스게임 목록" 전용: 비활성화 포함 (isActive 조건 제거)
-    @Query("""
-        SELECT gv
-        FROM GameVote gv
-        WHERE gv.member.id = :memberId
-          AND gv.gameOption.id IN :gameOptionIds
-        ORDER BY gv.createdAt DESC
-        LIMIT 1
-        """)
-    GameVote findLatestVoteByMemberIdAndGameOptionIds(
-            @Param("memberId") Long memberId,
-            @Param("gameOptionIds") List<Long> gameOptionIds
+    GameVote findTopByMember_IdAndGameOption_IdInOrderByCreatedAtDesc(
+            Long memberId,
+            List<Long> gameOptionIds
     );
 
     // [2] 활성화된 투표만 조회 (기존 로직 그대로 사용 - 추후 사용 염두)

--- a/src/main/java/balancetalk/vote/domain/VoteRepository.java
+++ b/src/main/java/balancetalk/vote/domain/VoteRepository.java
@@ -1,17 +1,21 @@
 package balancetalk.vote.domain;
 
 import balancetalk.game.domain.GameSet;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 
 public interface VoteRepository extends JpaRepository<GameVote, Long> {
 
-    @Query("SELECT v FROM GameVote v WHERE v.member.id = :memberId AND v.gameOption IS NOT NULL ORDER BY v.lastModifiedAt DESC")
-    Page<GameVote> findAllByMemberIdAndGameDesc(Long memberId, Pageable pageable);
-
+    @Query("""
+    SELECT gv FROM GameVote gv
+    WHERE gv.member.id = :memberId
+    AND gv.gameOption.id IN :gameOptionIds
+    ORDER BY gv.createdAt DESC
+    LIMIT 1""")
+    GameVote findFirstByMemberIdAndGameOptionIdIn(@Param("memberId") Long memberId,
+                                                  @Param("gameOptionIds") List<Long> gameOptionIds);
     void deleteAllByMemberIdAndGameOption_Game_GameSet(Long memberId, GameSet gameSet);
 }

--- a/src/main/java/balancetalk/vote/domain/VoteRepository.java
+++ b/src/main/java/balancetalk/vote/domain/VoteRepository.java
@@ -11,16 +11,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface VoteRepository extends JpaRepository<GameVote, Long> {
 
-    @Query("""
-    SELECT gv FROM GameVote gv
-    WHERE gv.member.id = :memberId
-    AND gv.isActive = true
-    AND gv.gameOption.id IN :gameOptionIds
-    ORDER BY gv.createdAt DESC
-    LIMIT 1
-""")
-    GameVote findFirstByMemberIdAndGameOptionIdIn(@Param("memberId") Long memberId, @Param("gameOptionIds") List<Long> gameOptionIds);
-
     // [1] "내가 투표한 밸런스게임 목록" 전용: 비활성화 포함 (isActive 조건 제거)
     @Query("""
         SELECT gv
@@ -35,7 +25,7 @@ public interface VoteRepository extends JpaRepository<GameVote, Long> {
             @Param("gameOptionIds") List<Long> gameOptionIds
     );
 
-    // [2] 활성화된 투표만 조회 (기존 로직 그대로 사용 - 필요하면 유지)
+    // [2] 활성화된 투표만 조회 (기존 로직 그대로 사용 - 추후 사용 염두)
     @Query("""
         SELECT gv
         FROM GameVote gv

--- a/src/main/java/balancetalk/vote/domain/VoteRepository.java
+++ b/src/main/java/balancetalk/vote/domain/VoteRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.repository.query.Param;
 public interface VoteRepository extends JpaRepository<GameVote, Long> {
 
     // [1] "내가 투표한 밸런스게임 목록" 전용: 비활성화 포함 (isActive 조건 제거)
-    GameVote findTopByMember_IdAndGameOption_IdInOrderByCreatedAtDesc(
+    GameVote findTopByMemberIdAndGameOptionIdInOrderByCreatedAtDesc(
             Long memberId,
             List<Long> gameOptionIds
     );

--- a/src/main/java/balancetalk/vote/domain/VoteRepository.java
+++ b/src/main/java/balancetalk/vote/domain/VoteRepository.java
@@ -19,7 +19,7 @@ public interface VoteRepository extends JpaRepository<GameVote, Long> {
           AND gv.gameOption.id IN :gameOptionIds
         ORDER BY gv.createdAt DESC
         LIMIT 1
-    """)
+        """)
     GameVote findLatestVoteByMemberIdAndGameOptionIds(
             @Param("memberId") Long memberId,
             @Param("gameOptionIds") List<Long> gameOptionIds
@@ -32,7 +32,7 @@ public interface VoteRepository extends JpaRepository<GameVote, Long> {
         WHERE gv.member.id = :memberId
           AND gv.gameOption.game.id = :gameId
           AND gv.isActive = true
-    """)
+        """)
     Optional<GameVote> findActiveVoteByMemberIdAndGameId(@Param("memberId") Long memberId,
                                                          @Param("gameId") Long gameId);
 
@@ -40,9 +40,10 @@ public interface VoteRepository extends JpaRepository<GameVote, Long> {
     @Query("""
         UPDATE GameVote gv SET gv.isActive = false 
         WHERE gv.member.id = :memberId AND gv.gameOption.game.gameSet = :gameSet
-    """)
+        """)
     void updateVotesAsInactive(@Param("memberId") Long memberId, @Param("gameSet") GameSet gameSet);
 
     // 특정 사용자가 특정 게임에 대해 투표한 기록 조회 (비활성화된 투표도 포함)
     @Query("SELECT gv FROM GameVote gv WHERE gv.member.id = :memberId AND gv.gameOption.game.id = :gameId")
-    Optional<GameVote> findByMemberIdAndGameId(@Param("memberId") Long memberId, @Param("gameId") Long gameId);}
+    Optional<GameVote> findByMemberIdAndGameId(@Param("memberId") Long memberId, @Param("gameId") Long gameId);
+}

--- a/src/main/java/balancetalk/vote/dto/VoteGameDto.java
+++ b/src/main/java/balancetalk/vote/dto/VoteGameDto.java
@@ -24,6 +24,7 @@ public class VoteGameDto {
             return GameVote.builder()
                     .member(member)
                     .gameOption(gameOption)
+                    .isActive(true)
                     .build();
         }
     }


### PR DESCRIPTION
## 💡 작업 내용
- [x] '내가 투표한 밸런스게임' 조회 시 같은 gameSetId를 가진 여러 game들이 조회되는 이슈 해결
- [x] '내가 투표한 밸런스 게임' 조회 시 해당 밸런스게임의 bookmarked 필드가 정상적으로 반영되지 않는 이슈 해결 
- [x] '밸런스게임 최종 북마크' 완료 시 '내가 투표한 밸런스 게임' 에서 해당 밸런스게임 세트를 가진 밸런스게임들이 모두 없어지는 이슈 해결

### postman 테스트 완료

## 💡 자세한 설명
### '내가 투표한 밸런스게임' 조회 시 같은 gameSetId를 가진 여러 game들이 조회되는 이슈 해결
'내가 투표한 밸런스게임' 조회 시, '밸런스게임 세트' 를 기준으로 보여져야 합니다.
즉, 하나의 밸런스게임 세트에 있는 게임들 여러 개에 투표를 했다고 하더라도, 가장 최근 밸런스게임의 투표 기록이 보여져야 합니다.

**JPA 쿼리 메서드를 새로 작성**함으로서, 해당 이슈를 해결했습니다.
```java
    // [1] "내가 투표한 밸런스게임 목록" 전용: 비활성화 포함 (isActive 조건 제거)
    @Query("""
        SELECT gv
        FROM GameVote gv
        WHERE gv.member.id = :memberId
          AND gv.gameOption.id IN :gameOptionIds
        ORDER BY gv.createdAt DESC
        LIMIT 1
    """)
    GameVote findLatestVoteByMemberIdAndGameOptionIds(
            @Param("memberId") Long memberId,
            @Param("gameOptionIds") List<Long> gameOptionIds
    );
```

### '내가 투표한 밸런스 게임' 조회 시 해당 밸런스게임의 bookmarked 필드가 정상적으로 반영되지 않는 이슈 해결 
해당 이슈는 마이페이지 **DTO에서, `bookmarked` 필드를 반환하지 않고 있어서 발생한 이슈였습니다.**
해당 응답 메서드들에 아래와 같이 `GameBookmark` 여부를 반환하게 함으로서 이슈를 해결했습니다.
```java
        public static GameMyPageResponse from(Game game, GameBookmark gameBookmark, GameVote vote, String imgA, String imgB) {
            return GameMyPageResponse.builder()
                    .writerId(game.getWriterId())
                    .gameSetId(game.getGameSet().getId())
                    .gameId(game.getId())
                    .title(game.getGameSet().getTitle())
                    .optionAImg(imgA)
                    .optionBImg(imgB)
                    .voteOption(vote.getVoteOption())
                    .subTag(game.getGameSet().getSubTag())
                    .mainTagName(game.getGameSet().getMainTag().getName())
                    .isBookmarked(isBookmarkedAndNotNull(gameBookmark))
                    .editedAt(game.getEditedAt())
                    .build();
        }


        private static boolean isBookmarkedAndNotNull(GameBookmark gameBookmark) {
            return (gameBookmark != null) && gameBookmark.isActive();
        }
    }
```

### '밸런스게임 최종 북마크' 완료 시 '내가 투표한 밸런스 게임' 에서 해당 밸런스게임 세트를 가진 밸런스게임들이 모두 없어지는 이슈 해결

해당 이슈는 발생 경위가 좀 복잡합니다.

기존의 북마크 & 투표 로직에 관해 먼저 설명드리자면,
1. 밸런스게임 최종 북마크 시, 해당 밸런스게임의 '재투표' 가 가능해야 함.
2. 따라서 밸런스게임 최종 북마크 시, 해당 회원이 해당 밸런스게임 세트에 투표 했던 기록을 지우고 있음(투표 카운트 수 제외)
```java
    public void createEndGameSetBookmark(final Long gameSetId, final ApiMember apiMember) {
        GameSet gameSet = gameReader.findGameSetById(gameSetId);
        Member member = apiMember.toMember(memberRepository);

...

        // 해당 멤버가 가진 GameSet 북마크 중, resourceId가 gameSetId와 일치하는 북마크가 있다면
        member.getGameBookmarkOf(gameSet)
                .ifPresentOrElse(
                        bookmark -> {
                            increaseBookmarkCountForActivation(bookmark, gameSet);
                            bookmark.activate();
                            bookmark.setIsEndGameSet(true); // 밸런스게임 세트 종료 표시
                            // 아래 코드에서 이슈 발생
                            voteRepository.deleteAllByMemberIdAndGameOption_Game_GameSet(member.getId(), gameSet);
                            bookmark.updateGameId(gameId); //gameId도 업데이트
                        },
                        () -> { // resourceId가 gameSetId와 일치하는 북마크가 없다면 새로 생성
                            gameBookmarkRepository.save(bookmarkGenerator.generate(gameSet, gameId, member));
                            gameSet.increaseBookmarks();
                            sendBookmarkGameNotification(gameSet);
                        });
    }
```
3. 해당 기록들이 아예 지워지기 때문에 '내가 투표한 밸런스게임' 조회 시 해당 밸런스게임들이 다 사라지는 이슈 발생

이를 해결하기 위해, `GameVote` 삭제 시 **'논리적 제거'** 방법을 다시 사용하도록 변경했습니다.
`GameVote` 에 활성화 여부인 `private boolean isActive;` 필드를 추가하고, 기존의 투표 생성/삭제 로직(VoteGameService)에서 **GameVote가 논리적으로만 변경**되도록 수정했습니다.

또한 '내가 투표한 밸런스 게임' 에서는 과거 투표(비활성화 포함)도 보여져야 하므로, `VoteRepository` 에 그를 위한 JPA 쿼리도 추가했습니다.

```java
    // [1] "내가 투표한 밸런스게임 목록" 전용: 비활성화 포함 (isActive 조건 제거)
    @Query("""
        SELECT gv
        FROM GameVote gv
        WHERE gv.member.id = :memberId
          AND gv.gameOption.id IN :gameOptionIds
        ORDER BY gv.createdAt DESC
        LIMIT 1
    """)
    GameVote findLatestVoteByMemberIdAndGameOptionIds(
            @Param("memberId") Long memberId,
            @Param("gameOptionIds") List<Long> gameOptionIds
    );
```

```java
    @Modifying
    @Query("""
        UPDATE GameVote gv SET gv.isActive = false 
        WHERE gv.member.id = :memberId AND gv.gameOption.game.gameSet = :gameSet
    """)
    void updateVotesAsInactive(@Param("memberId") Long memberId, @Param("gameSet") GameSet gameSet);
```
## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #878


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 내 프로필 페이지에 최신 투표 게임 목록을 확인할 수 있는 기능이 추가되었습니다.
  
- **Refactor**
  - 즐겨찾기 활성화 시 기존 투표가 삭제되는 대신 비활성 상태로 전환되어 데이터 보존과 일관성이 향상되었습니다.
  - 게임 관련 응답 처리 로직이 개선되어 즐겨찾기 및 투표 상태가 보다 명확하게 반영됩니다.
  - 투표 생성 시 기존 투표의 활성 상태를 체크하여 중복 제출을 방지하는 로직이 추가되었습니다.
  - 투표 상태 관리가 개선되어 비활성화된 투표도 시스템에 남아있도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->