### PR TITLE
조회 시 LazyInitializationException 오류 해결 

### DIFF
--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -40,6 +40,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -56,6 +57,7 @@ public class MyPageService {
     private final GameSetRepository gameSetRepository;
     private final FileRepository fileRepository;
 
+    @Transactional(readOnly = true)
     public Page<TalkPickMyPageResponse> findAllBookmarkedTalkPicks(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
         Page<TalkPickBookmark> bookmarks =
@@ -71,6 +73,7 @@ public class MyPageService {
         return new PageImpl<>(responses, pageable, bookmarks.getTotalElements());
     }
 
+    @Transactional(readOnly = true)
     public Page<TalkPickMyPageResponse> findAllVotedTalkPicks(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
         Page<TalkPickVote> votes = talkPickVoteRepository.findAllByMemberIdAndTalkPickDesc(member.getId(), pageable);
@@ -82,6 +85,7 @@ public class MyPageService {
         return new PageImpl<>(responses, pageable, votes.getTotalElements());
     }
 
+    @Transactional(readOnly = true)
     public Page<TalkPickMyPageResponse> findAllCommentedTalkPicks(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
         Page<Comment> comments =
@@ -94,6 +98,7 @@ public class MyPageService {
         return new PageImpl<>(responses, pageable, comments.getTotalElements());
     }
 
+    @Transactional(readOnly = true)
     public Page<TalkPickMyPageResponse> findAllTalkPicksByMember(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
         Page<TalkPick> talkPicks = talkPickRepository.findAllByMemberIdOrderByEditedAtDesc(member.getId(), pageable);
@@ -105,6 +110,7 @@ public class MyPageService {
         return new PageImpl<>(responses, pageable, talkPicks.getTotalElements());
     }
 
+    @Transactional(readOnly = true)
     public Page<GameMyPageResponse> findAllBookmarkedGames(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
         Page<GameBookmark> bookmarks = gameBookmarkRepository.findActivatedByMemberOrderByDesc(member, pageable);
@@ -128,7 +134,7 @@ public class MyPageService {
                 .toList();
     }
 
-
+    @Transactional(readOnly = true)
     public Page<GameMyPageResponse> findAllVotedGames(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
 
@@ -158,6 +164,7 @@ public class MyPageService {
         return new PageImpl<>(responses, pageable, responses.size());
     }
 
+    @Transactional(readOnly = true)
     public Page<GameMyPageResponse> findAllGamesByMember(ApiMember apiMember, Pageable pageable) {
         Member member = apiMember.toMember(memberRepository);
         Page<GameSet> gameSets = gameSetRepository.findAllByMemberIdOrderByEditedAtDesc(member.getId(), pageable);
@@ -194,6 +201,7 @@ public class MyPageService {
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.INVALID_SOURCE_TYPE));
     }
 
+    @Transactional(readOnly = true)
     public MemberActivityResponse getMemberActivity(ApiMember apiMember) {
         Member member = apiMember.toMember(memberRepository);
         return MemberActivityResponse.fromEntity(member);

--- a/src/main/java/balancetalk/talkpick/application/TodayTalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TodayTalkPickService.java
@@ -54,6 +54,7 @@ public class TodayTalkPickService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public List<TodayTalkPickResponse> findTodayTalkPick() {
         return todayTalkPickRepository.findByPickDate(LocalDate.now())
                 .stream()


### PR DESCRIPTION
## 💡 작업 내용
- [x] `open-in-view` 설정 false로 변경
- [x] 마이페이지 조회 로직에 `readOnly = true` 어노테이션 추가

## 💡 자세한 설명

알람 SSE로 인하여 OSIV 설정을 false로 변경했습니다. 그로 인해서 조회 시에 `LazyInitializationException` 오류가 발생했습니다.

자세한 내용은 https://jschoi96.tistory.com/183 여기 작성했습니다.

### 조회 시 에러 발생했던 API

- [ ] 내가 작성한 톡픽 목록 조회
- [ ] 투표한 톡픽 목록 조회
- [ ] 내가 댓글 단 톡픽 목록 조회
- [ ] 북마크한 톡픽 목록 조회
- [ ] 내가 작성한 밸런스 게임 목록 조회
- [ ] 투표한 밸런스 게임 목록 조회
- [ ] 북마크한 밸런스 게임 목록 조회
- [ ] 회원 활동 정보 조회
- [ ] 오늘의 톡픽 조회


## 📗 참고 자료 (선택)

https://lordofkangs.tistory.com/423

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #884 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 사용자 프로필 및 오늘의 추천 기능 등 데이터 조회 처리 과정에 읽기 전용 모드를 적용해 안정성과 성능을 개선했습니다.

- **Chores**
  - 시스템 구성 파일을 업데이트하여 최신 종속성이 반영되도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->