### PR TITLE
랜덤 밸런스 게임 실행 API 생성

### DIFF
--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -302,4 +302,10 @@ public class GameService {
         MainTag mainTag = request.toEntity();
         mainTagRepository.save(mainTag);
     }
+
+    @Transactional(readOnly = true)
+    public GameSetDetailResponse findRandomGame(final GuestOrApiMember guestOrApiMember) {
+        Long randomGameSetId = gameSetRepository.findRandomGameSetId();
+        return findBalanceGameSet(randomGameSetId, guestOrApiMember);
+    }
 }

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -184,7 +184,8 @@ public class GameService {
         boolean isEndGameSet = (gameBookmark != null) && gameBookmark.getIsEndGameSet();
 
         Map<Long, VoteOption> voteOptionMap = gameSet.getGames().stream()
-                .map(game -> Map.entry(game.getId(), member.getVoteOnGameOption(member, game).map(GameVote::getVoteOption).orElse(null)))
+                .map(game -> Map.entry(game.getId(),
+                        member.getVoteOnGameOption(member, game).map(GameVote::getVoteOption).orElse(null)))
                 .collect(Collectors.toConcurrentMap(Map.Entry::getKey, Map.Entry::getValue));
 
         return GameSetDetailResponse.fromEntity(gameSet, gameBookmark, isEndGameSet,

--- a/src/main/java/balancetalk/game/application/GameService.java
+++ b/src/main/java/balancetalk/game/application/GameService.java
@@ -30,8 +30,6 @@ import balancetalk.vote.domain.VoteOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -153,14 +151,28 @@ public class GameService {
 
     @Transactional
     public GameSetDetailResponse findBalanceGameSet(final Long gameSetId, final GuestOrApiMember guestOrApiMember) {
+        GameSet gameSet = getGameSetById(gameSetId);
+        return getGameSetDetailResponse(gameSet, guestOrApiMember);
+    }
+
+    @Transactional
+    public GameSetDetailResponse findRandomGame(final GuestOrApiMember guestOrApiMember) {
+        Long randomGameSetId = gameSetRepository.findRandomGameSetId();
+        GameSet gameSet = getGameSetById(randomGameSetId);
+        return getGameSetDetailResponse(gameSet, guestOrApiMember);
+    }
+    
+    private GameSet getGameSetById(Long gameSetId) {
         GameSet gameSet = gameSetRepository.findById(gameSetId)
                 .orElseThrow(() -> new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME_SET));
         gameSet.increaseViews();
+        return gameSet;
+    }
 
-        Map<Long, String> gameOptionImgUrls = getGameOptionImgUrls(gameSet); // 게임 id, 이미지 url을 가진 맵을 생성
+    private GameSetDetailResponse getGameSetDetailResponse(GameSet gameSet, GuestOrApiMember guestOrApiMember) {
+        Map<Long, String> gameOptionImgUrls = getGameOptionImgUrls(gameSet); // 게임 ID, 이미지 URL을 가진 맵 생성
 
         if (guestOrApiMember.isGuest()) { // 비회원인 경우
-            // 게스트인 경우 북마크, 선택 옵션 없음
             return GameSetDetailResponse.fromEntity(gameSet, null, false,
                     gameSet.getGames().stream()
                             .map(game -> GameDetailResponse.fromEntity(game, false, null, gameOptionImgUrls))
@@ -168,20 +180,12 @@ public class GameService {
         }
 
         Member member = guestOrApiMember.toMember(memberRepository);
-        List<Game> games = gameSet.getGames();
-
-        GameBookmark gameBookmark = member.getGameBookmarkOf(gameSet)
-                .orElse(null);
-
-        Map<Long, VoteOption> voteOptionMap = new ConcurrentHashMap<>();
-
+        GameBookmark gameBookmark = member.getGameBookmarkOf(gameSet).orElse(null);
         boolean isEndGameSet = (gameBookmark != null) && gameBookmark.getIsEndGameSet();
 
-        for (Game game : games) {
-            Optional<GameVote> myVote = member.getVoteOnGameOption(member, game);
-
-            myVote.ifPresent(gameVote -> voteOptionMap.put(game.getId(), gameVote.getVoteOption()));
-        }
+        Map<Long, VoteOption> voteOptionMap = gameSet.getGames().stream()
+                .map(game -> Map.entry(game.getId(), member.getVoteOnGameOption(member, game).map(GameVote::getVoteOption).orElse(null)))
+                .collect(Collectors.toConcurrentMap(Map.Entry::getKey, Map.Entry::getValue));
 
         return GameSetDetailResponse.fromEntity(gameSet, gameBookmark, isEndGameSet,
                 gameSet.getGames().stream()
@@ -301,11 +305,5 @@ public class GameService {
         }
         MainTag mainTag = request.toEntity();
         mainTagRepository.save(mainTag);
-    }
-
-    @Transactional(readOnly = true)
-    public GameSetDetailResponse findRandomGame(final GuestOrApiMember guestOrApiMember) {
-        Long randomGameSetId = gameSetRepository.findRandomGameSetId();
-        return findBalanceGameSet(randomGameSetId, guestOrApiMember);
     }
 }

--- a/src/main/java/balancetalk/game/domain/GameSet.java
+++ b/src/main/java/balancetalk/game/domain/GameSet.java
@@ -60,7 +60,7 @@ public class GameSet extends BaseTimeEntity {
     @ColumnDefault("0")
     private long views;
 
-    @Size(max = 10)
+    @Size(max = 32)
     private String subTag;
 
     @PositiveOrZero

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface GameSetRepository extends JpaRepository<GameSet, Long> {
+public interface GameSetRepository extends JpaRepository<GameSet, Long> , GameSetRepositoryCustom{
 
     Page<GameSet> findAllByMemberIdOrderByEditedAtDesc(Long memberId, Pageable pageable);
 
@@ -23,7 +23,7 @@ public interface GameSetRepository extends JpaRepository<GameSet, Long> {
     List<GameSet> findGamesByViews(@Param("name") String mainTag, Pageable pageable);
 
     @Query("SELECT g FROM GameSet g "
-            + "ORDER BY g.views DESC, " 
+            + "ORDER BY g.views DESC, "
             + "g.createdAt DESC")
     List<GameSet> findPopularGames(Pageable pageable);
 }

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface GameSetRepository extends JpaRepository<GameSet, Long> , GameSetRepositoryCustom{
+public interface GameSetRepository extends JpaRepository<GameSet, Long> ,GameSetRepositoryCustom {
 
     Page<GameSet> findAllByMemberIdOrderByEditedAtDesc(Long memberId, Pageable pageable);
 

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface GameSetRepository extends JpaRepository<GameSet, Long> ,GameSetRepositoryCustom {
+public interface GameSetRepository extends JpaRepository<GameSet, Long>, GameSetRepositoryCustom {
 
     Page<GameSet> findAllByMemberIdOrderByEditedAtDesc(Long memberId, Pageable pageable);
 

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepositoryCustom.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepositoryCustom.java
@@ -1,0 +1,5 @@
+package balancetalk.game.domain.repository;
+
+public interface GameSetRepositoryCustom {
+    Long findRandomGameSetId();
+}

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepositoryCustomImpl.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepositoryCustomImpl.java
@@ -1,0 +1,60 @@
+package balancetalk.game.domain.repository;
+
+import static balancetalk.game.domain.QGameSet.gameSet;
+
+import balancetalk.global.exception.BalanceTalkException;
+import balancetalk.global.exception.ErrorCode;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GameSetRepositoryCustomImpl implements GameSetRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Long findRandomGameSetId() {
+        // 1. MIN, MAX ID 조회
+        NumberTemplate<Long> maxId = Expressions.numberTemplate(Long.class,
+                "MAX({0})", gameSet.id);
+        NumberTemplate<Long> minId = Expressions.numberTemplate(Long.class,
+                "MIN({0})", gameSet.id);
+
+        Tuple minMaxResult = queryFactory
+                .select(minId, maxId)
+                .from(gameSet)
+                .fetchOne();
+
+        if (minMaxResult == null) {
+            throw new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME);
+        }
+
+        Long min = minMaxResult.get(minId);
+        Long max = minMaxResult.get(maxId);
+
+        if (min == null || max == null) {
+            throw new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME);
+        }
+
+        // 2. 랜덤 ID 생성
+        long randomId = min + (long)(Math.random() * (max - min + 1));
+
+        // 3. randomId 이상의 첫 번째 ID 조회
+        Long result = queryFactory
+                .select(gameSet.id)
+                .from(gameSet)
+                .where(gameSet.id.goe(randomId))
+                .orderBy(gameSet.id.asc())
+                .limit(1)
+                .fetchFirst();
+
+        if (result == null) {
+            throw new BalanceTalkException(ErrorCode.NOT_FOUND_BALANCE_GAME);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/balancetalk/game/domain/repository/GameSetRepositoryCustomImpl.java
+++ b/src/main/java/balancetalk/game/domain/repository/GameSetRepositoryCustomImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -40,7 +41,7 @@ public class GameSetRepositoryCustomImpl implements GameSetRepositoryCustom {
         }
 
         // 2. 랜덤 ID 생성
-        long randomId = min + (long)(Math.random() * (max - min + 1));
+        long randomId = ThreadLocalRandom.current().nextLong(min, max + 1);
 
         // 3. randomId 이상의 첫 번째 ID 조회
         Long result = queryFactory

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -50,6 +50,13 @@ public class GameController {
         return gameService.findBalanceGameSet(gameSetId, guestOrApiMember);
     }
 
+    @GetMapping("/random")
+    @Operation(summary = "랜덤 밸런스 게임 조회",
+            description = "랜덤으로 id를 가져와 밸런스 게임을 조회한다.")
+    public GameSetDetailResponse findRandomGame(@AuthPrincipal final GuestOrApiMember guestOrApiMember) {
+        return gameService.findRandomGame(guestOrApiMember);
+    }
+
     @DeleteMapping("/{gameSetId}")
     @Operation(summary = "밸런스 게임 세트 삭제", description = "밸런스 게임 세트를 삭제합니다.")
     public void deleteGameSet(@PathVariable final Long gameSetId,
@@ -80,12 +87,5 @@ public class GameController {
     ) {
         Pageable pageable = PageRequest.of(page, size);
         return gameService.findPopularGames(tagName, pageable, guestOrApiMember);
-    }
-
-    @GetMapping("/random")
-    @Operation(summary = "랜덤 밸런스 게임 조회",
-        description = "랜덤으로 id를 가져와 밸런스 게임을 조회한다.")
-    public GameSetDetailResponse findRandomGame(@AuthPrincipal final GuestOrApiMember guestOrApiMember) {
-        return gameService.findRandomGame(guestOrApiMember);
     }
 }

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -81,4 +81,11 @@ public class GameController {
         Pageable pageable = PageRequest.of(page, size);
         return gameService.findPopularGames(tagName, pageable, guestOrApiMember);
     }
+
+    @GetMapping("/random")
+    @Operation(summary = "랜덤 밸런스 게임 조회",
+        description = "랜덤으로 id를 가져와 밸런스 게임을 조회한다.")
+    public GameSetDetailResponse findRandomGame(@AuthPrincipal final GuestOrApiMember guestOrApiMember) {
+        return gameService.findRandomGame(guestOrApiMember);
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 서브 태그 값 제한 10 -> 32로 변경
- [x] queryDSL을 사용하여 랜덤으로 밸런스 게임 조회 구현

## 💡 자세한 설명
(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #874 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- 새로운 랜덤 게임 조회 기능이 추가되어, 사용자는 무작위 게임 세트를 받아볼 수 있게 되었습니다.
	- 게임 태그 입력의 최대 길이가 10자에서 32자로 확장되어, 더 다양한 태그 입력이 가능합니다.
	- API에 랜덤 게임 조회를 위한 새로운 엔드포인트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->