### PR TITLE
톡픽 상세 조회 응답에 작성자 프로필 이미지 URL 추가

### DIFF
--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryCustom.java
@@ -3,6 +3,7 @@ package balancetalk.file.domain.repository;
 import balancetalk.file.domain.File;
 import balancetalk.file.domain.FileType;
 import java.util.List;
+import java.util.Optional;
 
 public interface FileRepositoryCustom {
 
@@ -14,5 +15,5 @@ public interface FileRepositoryCustom {
 
     List<File> findAllByResourceIdsAndFileType(List<Long> resourceIds, FileType fileType);
 
-    Long findIdByResourceIdAndFileType(Long resourceId, FileType fileType);
+    Optional<String> findImgUrlByResourceIdAndFileType(Long resourceId, FileType fileType);
 }

--- a/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
+++ b/src/main/java/balancetalk/file/domain/repository/FileRepositoryImpl.java
@@ -6,6 +6,7 @@ import balancetalk.file.domain.File;
 import balancetalk.file.domain.FileType;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -49,13 +50,10 @@ public class FileRepositoryImpl implements FileRepositoryCustom {
     }
 
     @Override
-    public Long findIdByResourceIdAndFileType(Long resourceId, FileType fileType) {
-        return queryFactory.select(file.id)
+    public Optional<String> findImgUrlByResourceIdAndFileType(Long resourceId, FileType fileType) {
+        return Optional.ofNullable(queryFactory.select(file.imgUrl)
                 .from(file)
-                .where(
-                        file.resourceId.eq(resourceId),
-                        file.fileType.eq(fileType)
-                )
-                .fetchOne();
+                .where(file.fileType.eq(fileType), file.resourceId.eq(resourceId))
+                .fetchOne());
     }
 }

--- a/src/main/java/balancetalk/talkpick/application/TalkPickService.java
+++ b/src/main/java/balancetalk/talkpick/application/TalkPickService.java
@@ -1,5 +1,6 @@
 package balancetalk.talkpick.application;
 
+import static balancetalk.file.domain.FileType.MEMBER;
 import static balancetalk.file.domain.FileType.TALK_PICK;
 import static balancetalk.global.exception.ErrorCode.NOT_FOUND_TALK_PICK;
 import static balancetalk.talkpick.dto.TalkPickDto.CreateTalkPickRequest;
@@ -57,8 +58,11 @@ public class TalkPickService {
         List<String> imgUrls = fileRepository.findImgUrlsByResourceIdAndFileType(talkPickId, TALK_PICK);
         List<Long> fileIds = fileRepository.findIdsByResourceIdAndFileType(talkPickId, TALK_PICK);
 
+        String writerImgUrl = fileRepository.findImgUrlByResourceIdAndFileType(talkPick.getMemberId(), MEMBER)
+                .orElse(null);
+
         if (guestOrApiMember.isGuest()) {
-            return TalkPickDetailResponse.from(talkPick, imgUrls, fileIds, false, null);
+            return TalkPickDetailResponse.from(talkPick, writerImgUrl, imgUrls, fileIds, false, null);
         }
 
         Member member = guestOrApiMember.toMember(memberRepository);
@@ -66,10 +70,15 @@ public class TalkPickService {
         Optional<TalkPickVote> myVote = member.getVoteOnTalkPick(talkPick);
 
         if (myVote.isEmpty()) {
-            return TalkPickDetailResponse.from(talkPick, imgUrls, fileIds, hasBookmarked, null);
+            return TalkPickDetailResponse.from(talkPick, writerImgUrl, imgUrls, fileIds, hasBookmarked, null);
         }
 
-        return TalkPickDetailResponse.from(talkPick, imgUrls, fileIds, hasBookmarked, myVote.get().getVoteOption());
+        return TalkPickDetailResponse.from(talkPick,
+                writerImgUrl,
+                imgUrls,
+                fileIds,
+                hasBookmarked,
+                myVote.get().getVoteOption());
     }
 
     public Page<TalkPickResponse> findPaged(Pageable pageable) {

--- a/src/main/java/balancetalk/talkpick/domain/TalkPick.java
+++ b/src/main/java/balancetalk/talkpick/domain/TalkPick.java
@@ -122,6 +122,10 @@ public class TalkPick extends BaseTimeEntity {
         return this.member.getNickname();
     }
 
+    public Long getMemberId() {
+        return this.member.getId();
+    }
+
     public void increaseBookmarks() {
         this.bookmarks++;
     }

--- a/src/main/java/balancetalk/talkpick/domain/TalkPickImage.java
+++ b/src/main/java/balancetalk/talkpick/domain/TalkPickImage.java
@@ -1,0 +1,39 @@
+package balancetalk.talkpick.domain;
+
+import balancetalk.global.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TalkPickImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Size(max = 2083)
+    private String url;
+
+    @NotBlank
+    @Size(max = 50)
+    private String uploadName;
+
+    @NotBlank
+    @Size(max = 50)
+    private String storedName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "talk_pick_id")
+    private TalkPick talkPick;
+}

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -132,6 +132,9 @@ public class TalkPickDto {
         @Schema(description = "작성자 닉네임", example = "hj30")
         private String writer;
 
+        @Schema(description = "작성자 프로필 이미지 URL", example = "https://test.net/image.png")
+        private String writerProfileImgUrl;
+
         @Schema(description = "작성일", example = "2024-08-04")
         private LocalDate createdAt;
 
@@ -139,6 +142,7 @@ public class TalkPickDto {
         private Boolean isEdited;
 
         public static TalkPickDetailResponse from(TalkPick entity,
+                                                  String writerProfileImgUrl,
                                                   List<String> imgUrls,
                                                   List<Long> fileIds,
                                                   boolean myBookmark,
@@ -163,6 +167,7 @@ public class TalkPickDto {
                     .myBookmark(myBookmark)
                     .votedOption(votedOption)
                     .writer(entity.getWriterNickname())
+                    .writerProfileImgUrl(writerProfileImgUrl)
                     .createdAt(entity.getCreatedAt().toLocalDate())
                     .isEdited(entity.isEdited())
                     .build();

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -55,10 +55,6 @@ public class TalkPickDto {
                     .editedAt(LocalDateTime.now())
                     .build();
         }
-
-        public boolean containsFileIds() {
-            return fileIds != null;
-        }
     }
 
     @Schema(description = "톡픽 수정 요청")
@@ -87,18 +83,6 @@ public class TalkPickDto {
                     .summaryStatus(SummaryStatus.PENDING)
                     .editedAt(LocalDateTime.now())
                     .build();
-        }
-
-        public boolean containsNewFileIds() {
-            return newFileIds != null && !newFileIds.isEmpty();
-        }
-
-        public boolean containsDeleteFileIds() {
-            return deleteFileIds != null && !deleteFileIds.isEmpty();
-        }
-
-        public boolean notContainsAnyFileIds() {
-            return !containsNewFileIds() && !containsDeleteFileIds();
         }
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 톡픽 상세 조회 응답에 작성자 프로필 이미지 URL 추가

## 💡 자세한 설명
톡픽 상세 조회 응답에 작성자 프로필 이미지 URL 추가

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #888 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 토크 픽 상세 정보에 작성자 프로필 이미지가 추가되어, 사용자들이 작성자의 이미지를 확인할 수 있게 되었습니다.
	- 이미지 처리 및 관리 방식이 강화되어, 보다 안정적이고 일관된 이미지 데이터 제공이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->