### PR TITLE
밸런스 게임 조회 시 NPE 문제 해결 

### DIFF
--- a/src/main/java/balancetalk/game/dto/GameDto.java
+++ b/src/main/java/balancetalk/game/dto/GameDto.java
@@ -110,7 +110,6 @@ public class GameDto {
                 VoteOption votedOption,
                 Map<Long, String> gameOptionImgUrls
         ) {
-
             return GameDetailResponse.builder()
                     .id(game.getId())
                     .description(game.getDescription())

--- a/src/main/java/balancetalk/game/presentation/GameController.java
+++ b/src/main/java/balancetalk/game/presentation/GameController.java
@@ -54,7 +54,8 @@ public class GameController {
     @Operation(summary = "랜덤 밸런스 게임 조회",
             description = "랜덤으로 id를 가져와 밸런스 게임을 조회한다.")
     public GameSetDetailResponse findRandomGame(@AuthPrincipal final GuestOrApiMember guestOrApiMember) {
-        return gameService.findRandomGame(guestOrApiMember);
+        Long randomGameId = gameService.findRandomGame();
+        return gameService.findBalanceGameSet(randomGameId, guestOrApiMember);
     }
 
     @DeleteMapping("/{gameSetId}")


### PR DESCRIPTION
## 💡 작업 내용
- [x] 밸런스 게임 조회 시 500 에러 해결 

## 💡 자세한 설명

랜덤 밸런스 게임 API 비즈니스 로직은 이렇습니다.

1. 랜덤으로 게임 ID 가져옴
2. 그 값을 기반으로 밸런스 게임 상세조회 API 실행 

따라서, 기존의 상세 조회 비즈니스 로직을 `private` 메서드로 분리하고 랜덤 밸런스 게임 조회, 상세 조회 두가지 API에서 공통으로 사용되게 끔 리팩토링 했습니다.

![스크린샷 2025-02-22 오후 5 38 39](https://github.com/user-attachments/assets/39bb0dde-9847-4489-b2de-d31c9528fa7a)

비회원일 때는 문제가 없었지만 회원일 때 `NPE` 문제가 발생했습니다.

![스크린샷 2025-02-22 오후 11 38 14](https://github.com/user-attachments/assets/1882b2d7-c35c-489a-ac8f-70ec75bb84a0)

이를 해결하기 위해 서비스 로직에선 랜덤 ID값만 가져오고, 컨트롤러에선 상세 조회 API를 실행함으로써 문제를 해결했습니다. 



## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #890 
