### PR TITLE
마이페이지-톡픽 조회 응답 시 첨부한 이미지들 반환하도록 구현

### DIFF
--- a/src/main/java/balancetalk/member/application/MyPageService.java
+++ b/src/main/java/balancetalk/member/application/MyPageService.java
@@ -117,7 +117,8 @@ public class MyPageService {
 
         List<TalkPickMyPageResponse> responses = talkPicks.stream()
                 .map(talkPick -> {
-                    List<String> imgUrls = fileRepository.findImgUrlsByResourceIdAndFileType(talkPick.getId(), TALK_PICK);
+                    List<String> imgUrls =
+                            fileRepository.findImgUrlsByResourceIdAndFileType(talkPick.getId(), TALK_PICK);
                     return TalkPickMyPageResponse.fromMyTalkPick(talkPick, imgUrls);
                 })
                 .toList();

--- a/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepository.java
+++ b/src/main/java/balancetalk/talkpick/domain/repository/TalkPickRepository.java
@@ -1,5 +1,6 @@
 package balancetalk.talkpick.domain.repository;
 
+import balancetalk.member.domain.Member;
 import balancetalk.talkpick.domain.SummaryStatus;
 import balancetalk.talkpick.domain.TalkPick;
 import java.util.List;
@@ -9,7 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TalkPickRepository extends JpaRepository<TalkPick, Long>, TalkPickRepositoryCustom {
 
-    Page<TalkPick> findAllByMemberIdOrderByEditedAtDesc(Long memberId, Pageable pageable);
+    Page<TalkPick> findAllByMemberOrderByEditedAtDesc(Member member, Pageable pageable);
 
     List<TalkPick> findAllBySummaryStatus(SummaryStatus summaryStatus);
 }

--- a/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
+++ b/src/main/java/balancetalk/talkpick/dto/TalkPickDto.java
@@ -238,11 +238,19 @@ public class TalkPickDto {
         @Schema(description = "댓글 개수", example = "2")
         private long commentCount;
 
+        @Schema(description = "톡픽 작성 시 첨부한 이미지 URL 목록",
+                example = "["
+                        + "\"https://picko-image.amazonaws.com/temp-talk-pick/ad80-a94e083301d2_czz.png\",\n"
+                        + "\"https://picko-image.amazonaws.com/temp-talk-pick/957e6ed4830b_prom.jpeg\""
+                        + "]")
+        private List<String> imgUrls;
+
         @Schema(description = "최종 수정일(마이페이지 등록 날짜)")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
         private LocalDateTime editedAt;
 
-        public static TalkPickMyPageResponse from(TalkPick talkPick, TalkPickBookmark talkPickBookmark) {
+        public static TalkPickMyPageResponse from(TalkPick talkPick, TalkPickBookmark talkPickBookmark,
+                                                  List<String> imgUrls) {
             return TalkPickMyPageResponse.builder()
                     .id(talkPick.getId())
                     .title(talkPick.getTitle())
@@ -250,38 +258,42 @@ public class TalkPickDto {
                     .isBookmarked(talkPickBookmark.isActive())
                     .bookmarks(talkPick.getBookmarks())
                     .commentCount(!talkPick.getComments().isEmpty() ? talkPick.getComments().size() : 0)
+                    .imgUrls(imgUrls)
                     .editedAt(talkPick.getEditedAt())
                     .build();
         }
 
-        public static TalkPickMyPageResponse from(TalkPick talkPick, TalkPickVote vote) {
+        public static TalkPickMyPageResponse from(TalkPick talkPick, TalkPickVote vote, List<String> imgUrls) {
             return TalkPickMyPageResponse.builder()
                     .id(talkPick.getId())
                     .title(talkPick.getTitle())
                     .voteOption(vote.getVoteOption())
                     .bookmarks(talkPick.getBookmarks())
                     .commentCount(!talkPick.getComments().isEmpty() ? talkPick.getComments().size() : 0)
+                    .imgUrls(imgUrls)
                     .editedAt(talkPick.getEditedAt())
                     .build();
         }
 
-        public static TalkPickMyPageResponse from(TalkPick talkPick, Comment comment) {
+        public static TalkPickMyPageResponse from(TalkPick talkPick, Comment comment, List<String> imgUrls) {
             return TalkPickMyPageResponse.builder()
                     .id(talkPick.getId())
                     .title(talkPick.getTitle())
                     .commentContent(comment.getContent())
                     .bookmarks(talkPick.getBookmarks())
                     .commentCount(!talkPick.getComments().isEmpty() ? talkPick.getComments().size() : 0)
+                    .imgUrls(imgUrls)
                     .editedAt(talkPick.getEditedAt())
                     .build();
         }
 
-        public static TalkPickMyPageResponse fromMyTalkPick(TalkPick talkPick) {
+        public static TalkPickMyPageResponse fromMyTalkPick(TalkPick talkPick, List<String> imgUrls) {
             return TalkPickMyPageResponse.builder()
                     .id(talkPick.getId())
                     .title(talkPick.getTitle())
                     .bookmarks(talkPick.getBookmarks())
                     .commentCount(!talkPick.getComments().isEmpty() ? talkPick.getComments().size() : 0)
+                    .imgUrls(imgUrls)
                     .editedAt(talkPick.getEditedAt())
                     .build();
         }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 내가 작성한, 내가 댓글 단, 내가 투표한 톡픽 조회 시 톡픽에 첨부된 이미지 반환

## 💡 자세한 설명
마이페이지-톡픽 기능인 내가 작성한, 내가 댓글 단, 내가 투표한 톡픽 조회 시 톡픽에 첨부된 이미지를 반환하도록 구현했습니다. (프론트 요청)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #892 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MyPage에서 토크픽 항목에 관련 이미지가 함께 표시되어, 즐겨찾기, 투표, 댓글 등의 콘텐츠를 더욱 직관적으로 확인할 수 있습니다.
  - 토크픽 조회 방식이 개선되어, 사용자 맞춤 정보의 정확성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->