### PR TITLE
[모바일] 댓글 전체 조회 API 구현 완료

### DIFF
--- a/src/main/java/balancetalk/comment/application/CommentService.java
+++ b/src/main/java/balancetalk/comment/application/CommentService.java
@@ -134,6 +134,17 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
+    public List<LatestCommentResponse> findAllCommentsWhenMobile(Long talkPickId, GuestOrApiMember guestOrApiMember) {
+        validateTalkPickId(talkPickId);
+        talkPickRepository.findById(talkPickId)
+                .orElseThrow(() -> new BalanceTalkException(NOT_FOUND_TALK_PICK));
+
+        List<Comment> comments = commentRepository.findAllByTalkPickIdAndParentIsNullOrderByCreatedAtDesc(talkPickId);
+
+        return convertToLatestCommentResponse(comments, guestOrApiMember);
+    }
+
+    @Transactional(readOnly = true)
     public List<LatestCommentResponse> findAllReplies(Long parentId, Long talkPickId,
                                                       GuestOrApiMember guestOrApiMember) {
 

--- a/src/main/java/balancetalk/comment/domain/CommentRepository.java
+++ b/src/main/java/balancetalk/comment/domain/CommentRepository.java
@@ -12,6 +12,8 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findAllByTalkPickIdAndParentIsNull(Long talkPickId, Pageable pageable);
 
+    List<Comment> findAllByTalkPickIdAndParentIsNullOrderByCreatedAtDesc(Long talkPickId);
+
     @Query("SELECT c FROM Comment c WHERE c.parent.id = :parentId " +
             "ORDER BY CASE WHEN c.member.id = :currentMemberId THEN 0 ELSE 1 END, c.createdAt ASC")
     List<Comment> findAllRepliesByParentIdOrderByMemberAndCreatedAt(@Param("parentId") Long parentId,

--- a/src/main/java/balancetalk/comment/presentation/CommentController.java
+++ b/src/main/java/balancetalk/comment/presentation/CommentController.java
@@ -52,6 +52,16 @@ public class CommentController {
         return commentService.findAllComments(talkPickId, sortedByCreatedAtDesc, guestOrApiMember);
     }
 
+    @GetMapping("/m")
+    @Operation(summary = "모바일 - 최신 댓글 목록 조회",
+            description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글을 최신순으로 정렬해 조회한다.")
+    public List<LatestCommentResponse> findAllCommentsByPostIdSortedByCreatedAtMobile(
+            @PathVariable Long talkPickId,
+            @Parameter(hidden = true) @AuthPrincipal GuestOrApiMember guestOrApiMember) {
+
+        return commentService.findAllCommentsWhenMobile(talkPickId, guestOrApiMember);
+    }
+
     @GetMapping("/best")
     @Operation(summary = "베스트 댓글 목록 조회", description = "talkPick-id에 해당하는 게시글에 있는 모든 댓글을 베스트 및 좋아요 순으로 정렬해 조회한다.")
     public Page<BestCommentResponse> findAllBestCommentsByPostId(@PathVariable Long talkPickId, Pageable pageable,


### PR DESCRIPTION
## 💡 작업 내용
- [x] 댓글 최신순 일괄 조회 API 구현

## 💡 자세한 설명
프론트 요청으로 톡픽의 모든 댓글을 최신순으로 조회하는 API를 구현했습니다.
기존 API와 거의 동일하나, 페이지네이션을 사용하지 않고 리스트로 반환했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #894 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 모바일 사용자를 위한 최신 댓글 조회 기능이 추가되었습니다.  
    사용자는 특정 게시물의 최상위 댓글들을 최신순으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->